### PR TITLE
Modified the reflect function to allow reflections even if the angle between the vector and surface normal is acute

### DIFF
--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -85,9 +85,6 @@ class Vector2(Sequence):
         yield self.x
         yield self.y
 
-    def __neg__(self):
-        return self.rotate(180)
-
     def rotate(self, degrees):
         r = radians(degrees)
         r_cos = cos(r)

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -85,6 +85,9 @@ class Vector2(Sequence):
         yield self.x
         yield self.y
 
+    def __neg__(self):
+        return self.rotate(180)
+
     def rotate(self, degrees):
         r = radians(degrees)
         r_cos = cos(r)
@@ -114,6 +117,7 @@ class Vector2(Sequence):
         """
         if not (0.99999 < surface_normal.length < 1.00001):
             raise ValueError("Reflection requires a normalized vector.")
-        if self * surface_normal > 0:
-            self = -self
-        return self - (2 * (self * surface_normal) * surface_normal)
+        vec_new = self
+        if self * surface_normal>0:
+            vec_new = self.rotate(180)
+        return vec_new - (2 * (vec_new * surface_normal) * surface_normal)

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -9,7 +9,7 @@ class Vector2(Sequence):
         self.x = x
         self.y = y
         self.length = hypot(x, y)
-    
+
     def __len__(self):
         return 2
 
@@ -114,4 +114,6 @@ class Vector2(Sequence):
         """
         if not (0.99999 < surface_normal.length < 1.00001):
             raise ValueError("Reflection requires a normalized vector.")
+        if self * surface_normal > 0:
+            self = -self
         return self - (2 * (self * surface_normal) * surface_normal)

--- a/tests/test_vector2_reflect.py
+++ b/tests/test_vector2_reflect.py
@@ -5,7 +5,8 @@ reflect_data = (
     (Vector2(1, 1), Vector2(0, -1), Vector2(1, -1)),
     (Vector2(1, 1), Vector2(-1, 0), Vector2(-1, 1)),
     (Vector2(0, 1), Vector2(0, -1), Vector2(0, -1)),
-    (Vector2(-1, -1), Vector2(1, 0), Vector2(1, -1))
+    (Vector2(-1, -1), Vector2(1, 0), Vector2(1, -1)),
+    (Vector2(-1, -1), Vector2(-1, 0), Vector2(-1,1))
 )
 
 


### PR DESCRIPTION
The formula hold only if the angle between the surface normal and the ray is obtuse. An additional check is provided to check if the angle is obtuse and if not the ray is reversed to allow reflection.