### PR TITLE
Hypothesis: Add test for reflect()

### DIFF
--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -1,6 +1,6 @@
 import typing
 import collections
-from math import acos, cos, degrees, hypot, radians, sin
+from math import acos, cos, degrees, hypot, isclose, radians, sin
 from numbers import Real
 from collections.abc import Sequence
 
@@ -163,6 +163,8 @@ class Vector2(Sequence):
         r = radians(degrees)
         r_cos = cos(r)
         r_sin = sin(r)
+        assert isclose(r_cos * r_cos + r_sin * r_sin, 1)
+
         x = self.x * r_cos - self.y * r_sin
         y = self.x * r_sin + self.y * r_cos
         return Vector2(x, y)

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -163,8 +163,8 @@ class Vector2(Sequence):
         r = radians(degrees)
         r_cos = cos(r)
         r_sin = sin(r)
-        x = round(self.x * r_cos - self.y * r_sin, 5)
-        y = round(self.x * r_sin + self.y * r_cos, 5)
+        x = self.x * r_cos - self.y * r_sin
+        y = self.x * r_sin + self.y * r_cos
         return Vector2(x, y)
 
     def normalize(self) -> 'Vector2':

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -191,7 +191,5 @@ class Vector2(Sequence):
         surface_normal = _mkvector(surface_normal, castto=Vector2)
         if not (0.99999 < surface_normal.length < 1.00001):
             raise ValueError("Reflection requires a normalized vector.")
-        vec_new = self
-        if self * surface_normal > 0:
-            vec_new = self.rotate(180)
-        return vec_new - (2 * (vec_new * surface_normal) * surface_normal)
+
+        return self - (2 * (self * surface_normal) * surface_normal)

--- a/tests/test_vector2_reflect.py
+++ b/tests/test_vector2_reflect.py
@@ -1,5 +1,9 @@
 from ppb_vector import Vector2
 import pytest
+from hypothesis import given, assume, note
+from math import isclose
+from utils import units, vectors
+
 
 reflect_data = (
     (Vector2(1, 1), Vector2(0, -1), Vector2(1, -1)),
@@ -13,3 +17,13 @@ reflect_data = (
 @pytest.mark.parametrize("initial_vector, surface_normal, expected_vector", reflect_data)
 def test_reflect(initial_vector, surface_normal, expected_vector):
     assert initial_vector.reflect(surface_normal).isclose(expected_vector)
+
+
+@given(initial=vectors(), normal=units())
+def test_reflect_prop(initial: Vector2, normal: Vector2):
+    assume(initial ^ normal != 0)
+    reflected = initial.reflect(normal)
+    returned = reflected.reflect(normal)
+    note(f"Reflected: {reflected}")
+    assert initial.isclose(returned)
+    assert isclose((initial * normal), -(reflected * normal))

--- a/tests/test_vector2_reflect.py
+++ b/tests/test_vector2_reflect.py
@@ -12,4 +12,4 @@ reflect_data = (
 
 @pytest.mark.parametrize("initial_vector, surface_normal, expected_vector", reflect_data)
 def test_reflect(initial_vector, surface_normal, expected_vector):
-    assert initial_vector.reflect(surface_normal) == expected_vector
+    assert initial_vector.reflect(surface_normal).isclose(expected_vector)

--- a/tests/test_vector2_reflect.py
+++ b/tests/test_vector2_reflect.py
@@ -1,7 +1,7 @@
 from ppb_vector import Vector2
 import pytest
 from hypothesis import given, assume, note
-from math import isclose
+from math import isclose, isinf
 from utils import units, vectors
 
 
@@ -25,5 +25,6 @@ def test_reflect_prop(initial: Vector2, normal: Vector2):
     reflected = initial.reflect(normal)
     returned = reflected.reflect(normal)
     note(f"Reflected: {reflected}")
+    assert not any(map(isinf, reflected))
     assert initial.isclose(returned)
     assert isclose((initial * normal), -(reflected * normal))

--- a/tests/test_vector2_reflect.py
+++ b/tests/test_vector2_reflect.py
@@ -10,7 +10,7 @@ reflect_data = (
     (Vector2(1, 1), Vector2(-1, 0), Vector2(-1, 1)),
     (Vector2(0, 1), Vector2(0, -1), Vector2(0, -1)),
     (Vector2(-1, -1), Vector2(1, 0), Vector2(1, -1)),
-    (Vector2(-1, -1), Vector2(-1, 0), Vector2(-1,1))
+    (Vector2(-1, -1), Vector2(-1, 0), Vector2(1, -1))
 )
 
 

--- a/tests/test_vector2_reflect.py
+++ b/tests/test_vector2_reflect.py
@@ -2,7 +2,7 @@ from ppb_vector import Vector2
 import pytest
 from hypothesis import given, assume, note
 from math import isclose, isinf
-from utils import units, vectors
+from utils import angle_isclose, units, vectors
 
 
 reflect_data = (
@@ -28,3 +28,6 @@ def test_reflect_prop(initial: Vector2, normal: Vector2):
     assert not any(map(isinf, reflected))
     assert initial.isclose(returned)
     assert isclose((initial * normal), -(reflected * normal))
+    assert angle_isclose(normal.angle(initial),
+                         180 - normal.angle(reflected)
+    )

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -1,4 +1,5 @@
 from ppb_vector import Vector2
+from utils import angle_isclose
 import pytest
 import math
 
@@ -17,8 +18,9 @@ def isclose(x, y, epsilon = 6.5e-5):
 
 @pytest.mark.parametrize('input, degrees, expected', data)
 def test_multiple_rotations(input, degrees, expected):
-    assert input.rotate(degrees) == expected
-    assert isclose(input.angle(expected), degrees)
+    assert input.rotate(degrees).isclose(expected)
+    assert angle_isclose(input.angle(expected), degrees)
+
 
 def test_for_exception():
     with pytest.raises(TypeError):


### PR DESCRIPTION
~Based off #62~

The test failed without 248491f, because `tests.utils.units` returned not-quite-normalized vectors, because `Vector2.rotate()` rounded things off.  ~(You can check, adding `.normalize()` to the returned value in `units` “fixes” it.)~