### PR TITLE
setup.py: Add zip_safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
         'Topic :: Software Development',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6'
-    ]
+    ],
+    zip_safe=True,
 )


### PR DESCRIPTION
Explicitly declare ppb-vector to be zip_safe, so that egg and pyz tools can package it up.