### PR TITLE
Add property-based tests for cross-products

### DIFF
--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -158,7 +158,10 @@ class Vector2:
 
     def __xor__(self: VectorOrSub, other: VectorLike) -> Realish:
         """
-        Computes the magnitude of the cross product
+        Computes the magnitude of the cross product.
+
+        May overflow on the product of two large vectors
+        (operands length >= 10¹⁵⁰) and produce NaN.
         """
         other = Vector2.convert(other)
         return self.x * other.y - self.y * other.x

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -158,7 +158,7 @@ class Vector2:
 
     def __xor__(self: VectorOrSub, other: VectorLike) -> Realish:
         """
-        Computes the magnitude of the cross product.
+        Computes the z-coordinate of the cross product.
 
         May overflow on the product of two large vectors
         (operands length >= 10**150) and produce NaN.

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -161,7 +161,7 @@ class Vector2:
         Computes the magnitude of the cross product.
 
         May overflow on the product of two large vectors
-        (operands length >= 10¹⁵⁰) and produce NaN.
+        (operands length >= 10**150) and produce NaN.
         """
         other = Vector2.convert(other)
         return self.x * other.y - self.y * other.x

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -164,6 +164,14 @@ class Vector2:
         (operands length >= 10**150) and produce NaN.
         """
         other = Vector2.convert(other)
+        l = self.length
+
+        if l > 1e10:
+            # Preconditionning step, taken from Prof. W. Kahan's
+            #  https://people.eecs.berkeley.edu/~wkahan/MathH110/Cross.pdf
+            𝜚 = (self / l) * (other / l)
+            other -= 𝜚*self
+
         return self.x * other.y - self.y * other.x
 
     def __getitem__(self: VectorOrSub, item: typing.Union[str, int]) -> Realish:

--- a/tests/test_vector2_cross.py
+++ b/tests/test_vector2_cross.py
@@ -17,8 +17,9 @@ def test_cross(left, right, expected):
     assert right ^ left == -expected
 
 
-@given(a=vectors(), b=vectors(max_magnitude=1e150), c=vectors(),
-       l=st.floats(min_value=-1e150,max_value=1e150),
+@given(a=vectors(max_magnitude=1e150), c=vectors(max_magnitude=1e150),
+       b=vectors(max_magnitude=1e75),
+       l=st.floats(min_value=-1e75,max_value=1e75),
 )
 def test_cross_linearity(a: Vector2, b: Vector2, c: Vector2, l: Real):
     assert isclose(
@@ -26,6 +27,6 @@ def test_cross_linearity(a: Vector2, b: Vector2, c: Vector2, l: Real):
         l * (a ^ b) + (a ^ c)
     )
 
-@given(a=vectors(), b=vectors())
+@given(a=vectors(max_magnitude=1e150), b=vectors(max_magnitude=1e150))
 def test_cross_antisymetry(a: Vector2, b: Vector2):
     assert isclose(a ^ b, - b ^ a)

--- a/tests/test_vector2_cross.py
+++ b/tests/test_vector2_cross.py
@@ -1,4 +1,8 @@
 from ppb_vector import Vector2
+from hypothesis import given, strategies as st
+from math import isclose
+from numbers import Real
+from utils import vectors
 import pytest  # type: ignore
 
 @pytest.mark.parametrize("left, right, expected", [
@@ -11,3 +15,17 @@ import pytest  # type: ignore
 def test_cross(left, right, expected):
     assert left ^ right == expected
     assert right ^ left == -expected
+
+
+@given(a=vectors(), b=vectors(max_magnitude=1e150), c=vectors(),
+       l=st.floats(min_value=-1e150,max_value=1e150),
+)
+def test_cross_linearity(a: Vector2, b: Vector2, c: Vector2, l: Real):
+    assert isclose(
+        a ^ (l * b + c),
+        l * (a ^ b) + (a ^ c)
+    )
+
+@given(a=vectors(), b=vectors())
+def test_cross_antisymetry(a: Vector2, b: Vector2):
+    assert isclose(a ^ b, - b ^ a)

--- a/tests/test_vector2_cross.py
+++ b/tests/test_vector2_cross.py
@@ -1,5 +1,5 @@
 from ppb_vector import Vector2
-from hypothesis import given, strategies as st
+from hypothesis import given, note, strategies as st
 from math import isclose
 from numbers import Real
 from utils import vectors
@@ -22,11 +22,19 @@ def test_cross(left, right, expected):
        l=st.floats(min_value=-1e75,max_value=1e75),
 )
 def test_cross_linearity(a: Vector2, b: Vector2, c: Vector2, l: Real):
-    assert isclose(
-        a ^ (l * b + c),
-        l * (a ^ b) + (a ^ c)
-    )
+    factored = a ^ (l * b + c)
+    distributed = l * (a^b) + (a^c)
+
+    note(f"a ^ (l * b + c): {factored}")
+    note(f"l * (a^b) + (a^c): {distributed}")
+    assert isclose(factored, distributed)
 
 @given(a=vectors(max_magnitude=1e150), b=vectors(max_magnitude=1e150))
 def test_cross_antisymetry(a: Vector2, b: Vector2):
-    assert isclose(a ^ b, - b ^ a)
+    prod1 = a ^ b
+    prod2 = b ^ a
+
+    note(f"a ^ b: {prod1}")
+    note(f"b ^ a: {prod2}")
+    note(f"δ: {prod1 + prod2}")
+    assert isclose(prod1, -prod2)


### PR DESCRIPTION
PR targetting the branch for #65 

- [x] Add linearity and anti-symmetry test
- [x] Document that cross-products may overflow on large vectors
- [x] Restrict the generated vectors to avoid overflow (pulled in #69)
- [ ] Fix the exposed numerical instabilities in cross-products.