### PR TITLE
Vector2: Remove superfluous _length attribute

### DIFF
--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -59,7 +59,6 @@ def _find_lowest_vector(left: typing.Type, right: typing.Type) -> typing.Type:
 class Vector2:
     x: float
     y: float
-    _length: float
 
     def __init__(self, x: typing.SupportsFloat, y: typing.SupportsFloat):
         try:


### PR DESCRIPTION
It was used for memoizing length computations until #71.
I proved in a microbenchmark that the memoization was providing no benefit (as `math.hypot` isn't any slower than Python's reflection API, used to check if the value was already computed)
