### PR TITLE
Vector2: Add vector-scalar division

### DIFF
--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -155,6 +155,10 @@ class Vector2:
     def __rmul__(self, other):
         return self.__mul__(other)
 
+    def __truediv__(self: VectorOrSub, other: Realish) -> VectorOrSub:
+        """Perform a division between a vector and a scalar."""
+        return type(self)(self.x / other, self.y / other)
+
     def __getitem__(self: VectorOrSub, item: typing.Union[str, int]) -> Realish:
         if hasattr(item, '__index__'):
             item = item.__index__()  # type: ignore

--- a/tests/test_vector2_scalar_multiplication.py
+++ b/tests/test_vector2_scalar_multiplication.py
@@ -1,8 +1,9 @@
 import pytest  # type: ignore
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis.strategies import floats
 from math import isclose
 from utils import vectors
+
 from ppb_vector import Vector2
 
 
@@ -41,3 +42,10 @@ def test_scalar_linear(l: float, x: Vector2, y: Vector2):
 )
 def test_scalar_length(l: float, x: Vector2):
     assert isclose((l * x).length, abs(l) * x.length)
+
+
+@given(x=vectors(), l=floats(min_value=-1e150, max_value=1e150))
+def test_scalar_division(x: Vector2, l: float):
+    """Test that (x / λ) = (1 / λ) * x"""
+    assume(abs(l) > 1e-100)
+    assert (x / l).isclose((1/l) * x)


### PR DESCRIPTION
This is notation that's both convenient, and pretty usual in vector math.
`x / λ` is equivalent (up to floating-point errors) to `(1 / λ) * x`