### PR TITLE
Vector2.scale_to: Add Hypothesis tests, fix exposed bugs

### DIFF
--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -261,6 +261,9 @@ class Vector2:
         """
         Scale the vector to the given length
         """
+        if length < 0:
+            raise ValueError("Vector2.scale_to takes non-negative lengths.")
+
         return (length / self.length) * self
 
     scale = scale_to

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -261,11 +261,7 @@ class Vector2:
         """
         Scale the vector to the given length
         """
-        try:
-            scale = length / self.length
-        except ZeroDivisionError:
-            scale = 1
-        return self.scale_by(scale)
+        return (length / self.length) * self
 
     scale = scale_to
 

--- a/tests/test_vector2_normalize.py
+++ b/tests/test_vector2_normalize.py
@@ -3,13 +3,12 @@ import pytest  # type: ignore
 import ppb_vector
 
 
-@pytest.mark.parametrize("x, y, expected", [
-    (3, 4, 1),
-    (6, 8, 1),
-    (0, 1, 1),
-    (1, 0, 1),
-    (0, 0, 0)
+@pytest.mark.parametrize("x, y", [
+    (3, 4),
+    (6, 8),
+    (0, 1),
+    (1, 0),
 ])
-def test_normalize(x, y, expected):
+def test_normalize(x, y):
     vector = ppb_vector.Vector2(x, y).normalize()
-    assert vector.length == expected
+    assert vector.length == 1

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -1,23 +1,9 @@
 import pytest  # type: ignore
 from hypothesis import assume, given
 from hypothesis.strategies import floats
-from math import hypot
 from utils import vectors
 
 from ppb_vector import Vector2
-
-
-@pytest.fixture()
-def vector():
-    return Vector2(10, 20)
-
-
-def test_calculate_scale(vector):
-    x, y = 10, 20
-    length = hypot(x, y)
-    scale = 4
-    vector_scale_calculated = vector * (scale / length)
-    assert vector.scale(scale) == vector_scale_calculated
 
 
 @given(x=vectors(), l=floats(min_value=1e150, max_value=1e150))

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -8,8 +8,12 @@ from ppb_vector import Vector2
 
 
 @given(x=vectors(), l=floats(min_value=-1e150, max_value=1e150))
-def test_scale_length(x: Vector2, l: float):
-    assert isclose(x.scale_to(l).length, l)
+def test_scale_to_length(x: Vector2, l: float):
+    """Test that the length of x.scale_to(l) is l."""
+    try:
+        assert isclose(x.scale_to(l).length, l)
+    except ZeroDivisionError:
+        assert x == (0, 0)
 
 
 @given(x=vectors(), l=floats(min_value=1e150, max_value=1e150))

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -1,9 +1,15 @@
 import pytest  # type: ignore
 from hypothesis import assume, given
 from hypothesis.strategies import floats
+from math import isclose
 from utils import vectors
 
 from ppb_vector import Vector2
+
+
+@given(x=vectors(), l=floats(min_value=-1e150, max_value=1e150))
+def test_scale_length(x: Vector2, l: float):
+    assert isclose(x.scale_to(l).length, l)
 
 
 @given(x=vectors(), l=floats(min_value=1e150, max_value=1e150))

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -14,6 +14,8 @@ def test_scale_to_length(x: Vector2, l: float):
         assert isclose(x.scale_to(l).length, l)
     except ZeroDivisionError:
         assert x == (0, 0)
+    except ValueError:
+        assert l < 0
 
 
 @given(x=vectors(), l=floats(min_value=1e150, max_value=1e150))

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -1,5 +1,8 @@
 import pytest  # type: ignore
+from hypothesis import assume, given
+from hypothesis.strategies import floats
 from math import hypot
+from utils import vectors
 
 from ppb_vector import Vector2
 
@@ -17,11 +20,11 @@ def test_calculate_scale(vector):
     assert vector.scale(scale) == vector_scale_calculated
 
 
-def test_scale_is_equivalent_to_truncate():
-    """ 
-    Vector2.scale is equivalent to Vector2.truncate 
-    when scalar is less than length
+@given(x=vectors(), l=floats(min_value=1e150, max_value=1e150))
+def test_scale_is_equivalent_to_truncate(x: Vector2, l: float):
     """
-    vector_scale = Vector2(3, 4).scale(4)
-    vector_truncate = Vector2(3, 4).truncate(4)
-    assert vector_scale == vector_truncate
+    Vector2.scale_to is equivalent to Vector2.truncate
+    when the scalar is less than length
+    """
+    assume(l <= x.length)
+    assert x.scale_to(l) == x.truncate(l)


### PR DESCRIPTION
- [x] Turned test_scale_is_equivalent_to_truncate into an Hypothesis test.
- [x] Raise a ZeroDivisionError when scaling a null vector, rather than silently swallowing the error.
- [x] Raise a ValueError when scaling to a negative length.