### PR TITLE
Loosen test_scalar_linear

### DIFF
--- a/tests/test_vector2_scalar_multiplication.py
+++ b/tests/test_vector2_scalar_multiplication.py
@@ -28,9 +28,9 @@ def test_scalar_associative(x: float, y: float, v: Vector2):
     assert left.isclose(right)
 
 @given(
-    l=floats(min_value=-1e150, max_value=1e150),
-    x=vectors(max_magnitude=1e150),
-    y=vectors(max_magnitude=1e150),
+    l=floats(min_value=-1e75, max_value=1e75),
+    x=vectors(max_magnitude=1e75),
+    y=vectors(max_magnitude=1e75),
 )
 def test_scalar_linear(l: float, x: Vector2, y: Vector2):
     assert (l * (x + y)).isclose(l*x + l*y)


### PR DESCRIPTION
There are imprecisions, at high magnitudes, that caused CI to fail:

  https://travis-ci.org/ppb/ppb-vector/jobs/466531657#L719