### PR TITLE
tests: Complete the method lists

### DIFF
--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,28 +1,7 @@
 import pytest  # type: ignore
 
 from ppb_vector import Vector2
-
-# List of operations that (Vector2, Vector2) -> Vector2
-BINARY_OPS = [
-    Vector2.__add__,
-    Vector2.__sub__,
-    Vector2.reflect,
-]
-
-# List of operations that (Vector2, Real) -> Vector2
-VECTOR_NUMBER_OPS = [
-    Vector2.scale_by,
-    Vector2.rotate,
-    Vector2.truncate,
-    Vector2.scale_to,
-]
-
-# List of operations that (Vector2) -> Vector2
-UNARY_OPS = [
-    lambda v: type(v).convert(v),
-    Vector2.__neg__,
-    Vector2.normalize,
-]
+from utils import BINARY_OPS, SCALAR_OPS, UNARY_OPS
 
 @pytest.mark.parametrize('op', BINARY_OPS)
 def test_binop_same(op):
@@ -58,10 +37,10 @@ def test_binop_subclass(op):
     assert isinstance(b, V2)
 
 
-@pytest.mark.parametrize('op', VECTOR_NUMBER_OPS)
+@pytest.mark.parametrize('op', SCALAR_OPS)
 def test_vnumop(op):
     class V(Vector2): pass
-    
+
     a = op(V(1, 2), 42)
 
     assert isinstance(a, V)
@@ -70,7 +49,7 @@ def test_vnumop(op):
 @pytest.mark.parametrize('op', UNARY_OPS)
 def test_monop(op):
     class V(Vector2): pass
-    
+
     a = op(V(1, 2))
 
     assert isinstance(a, V)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,3 +17,26 @@ def units(draw, elements=st.floats(min_value=0, max_value=360)):
 def angle_isclose(x, y, epsilon = 6.5e-5):
     d = (x - y) % 360
     return (d < epsilon) or (d > 360 - epsilon)
+
+
+# List of operations that (Vector2, Vector2) -> Vector2
+BINARY_OPS = [
+    Vector2.__add__,
+    Vector2.__sub__,
+    Vector2.reflect,
+]
+
+# List of operations that (Vector2, Real) -> Vector2
+SCALAR_OPS = [
+    Vector2.scale_by,
+    Vector2.rotate,
+    Vector2.truncate,
+    Vector2.scale_to,
+]
+
+# List of operations that (Vector2) -> Vector2
+UNARY_OPS = [
+    lambda v: type(v).convert(v),
+    Vector2.__neg__,
+    Vector2.normalize,
+]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,17 +26,34 @@ BINARY_OPS = [
     Vector2.reflect,
 ]
 
+# List of (Vector2, Vector2) -> scalar operations
+BINARY_SCALAR_OPS = [
+    Vector2.angle,
+    Vector2.dot,
+]
+
+# List of (Vector2, Vector2) -> bool operations
+BOOL_OPS = [
+    Vector2.__eq__,
+    Vector2.isclose,
+]
+
 # List of operations that (Vector2, Real) -> Vector2
 SCALAR_OPS = [
-    Vector2.scale_by,
     Vector2.rotate,
-    Vector2.truncate,
+    Vector2.scale_by,
     Vector2.scale_to,
+    Vector2.truncate,
 ]
 
 # List of operations that (Vector2) -> Vector2
 UNARY_OPS = [
-    Vector2.convert,
     Vector2.__neg__,
+    Vector2.convert,
     Vector2.normalize,
+]
+
+# List of (Vector2) -> scalar operations
+UNARY_SCALAR_OPS = [
+    Vector2.length.fget,
 ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,5 +55,7 @@ UNARY_OPS = [
 
 # List of (Vector2) -> scalar operations
 UNARY_SCALAR_OPS = [
-    Vector2.length.fget,
+    Vector2.length.fget, # type: ignore
+                         # mypy fails to typecheck properties' attributes:
+                         #  https://github.com/python/mypy/issues/220
 ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,7 +36,7 @@ SCALAR_OPS = [
 
 # List of operations that (Vector2) -> Vector2
 UNARY_OPS = [
-    lambda v: type(v).convert(v),
+    Vector2.convert,
     Vector2.__neg__,
     Vector2.normalize,
 ]


### PR DESCRIPTION
- [x] Add methods that do not return a `Vector2`
- [x] Use `Vector2.convert` directly, rather than a lambda, so it has a human-meaningful name.