### PR TITLE
Property-based testing for truncate

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ less than length.
     >>> Vector2(3, 4).truncate(6)
     Vector2(3.0, 4.0)
 
+Note: `x.truncate(max_length)` may sometimes be slightly-larger than
+      `max_length`, due to floating-point rounding effects.
+
 ### reflect(surface_normal)
 
 Reflect a `Vector2` based on a given surface normal.

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -286,6 +286,9 @@ class Vector2:
         if length < 0:
             raise ValueError("Vector2.scale_to takes non-negative lengths.")
 
+        if length == 0:
+            return type(self)(0, 0)
+
         return (length * self) / self.length
 
     scale = scale_to

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -274,9 +274,10 @@ class Vector2:
         return self.scale(1)
 
     def truncate(self: VectorOrSub, max_length: Realish) -> VectorOrSub:
-        if self.length > max_length:
-            return self.scale_to(max_length)
-        return self
+        if self.length <= max_length:
+            return self
+
+        return self.scale_to(max_length)
 
     def scale_to(self: VectorOrSub, length: Realish) -> VectorOrSub:
         """

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -2,7 +2,7 @@ import pytest  # type: ignore
 from hypothesis import assume, given
 from hypothesis.strategies import floats
 from math import isclose
-from utils import vectors
+from utils import angle_isclose, vectors
 
 from ppb_vector import Vector2
 
@@ -16,3 +16,13 @@ def test_scale_to_length(x: Vector2, l: float):
         assert x == (0, 0)
     except ValueError:
         assert l < 0
+
+
+@given(x=vectors(max_magnitude=1e75), length=floats(min_value=0, max_value=1e75))
+def test_scale_aligned(x: Vector2, length: float):
+    """Test that the length of x.scale_to(length) is length."""
+    assume(length > 0)
+    try:
+        assert angle_isclose(x.scale_to(length).angle(x), 0)
+    except ZeroDivisionError:
+        assert x == (0, 0)

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -16,13 +16,3 @@ def test_scale_to_length(x: Vector2, l: float):
         assert x == (0, 0)
     except ValueError:
         assert l < 0
-
-
-@given(x=vectors(max_magnitude=1e75), l=floats(min_value=1e75, max_value=1e75))
-def test_scale_is_equivalent_to_truncate(x: Vector2, l: float):
-    """
-    Vector2.scale_to is equivalent to Vector2.truncate
-    when the scalar is less than length
-    """
-    assume(l <= x.length)
-    assert x.scale_to(l) == x.truncate(l)

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -19,7 +19,7 @@ def test_truncate_invariant(x: Vector2, max_length: float):
 
 @given(x=vectors(), max_length=floats())
 @example( # Large example where x.length == max_length but 1 * x != x
-    x=Vector2(0.0, 7.387424005855793e+62), max_length=7.387424005855793e+62
+    x=Vector2(0.0, 7.1e+62), max_length=7.1e+62
 )
 def test_truncate_equivalent_to_scale(x: Vector2, max_length: float):
     """Vector2.scale_to and truncate are equivalent when max_length <= x.length"""

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -1,5 +1,5 @@
 import pytest  # type: ignore
-from hypothesis import assume, example, given, note
+from hypothesis import assume, event, example, given, note
 from typing import Type, Union
 from utils import floats, lengths, vectors
 
@@ -39,6 +39,7 @@ def test_truncate_equivalent_to_scale(x: Vector2, max_length: float):
     try:
         scale = x.scale_to(max_length)
     except Exception as e:
+        event(f"Exception {type(e).__name__} thrown")
         scale = type(e)
 
     if isinstance(scale, Vector2) and x.length == max_length:

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -1,4 +1,8 @@
 import pytest  # type: ignore
+from hypothesis import assume, given
+from hypothesis.strategies import floats
+from typing import Type, Union
+from utils import vectors
 
 from ppb_vector import Vector2
 
@@ -43,3 +47,24 @@ data = [
 @pytest.mark.parametrize('test_input, expected', data)
 def test_multiples_values(test_input, expected):
     assert test_input[0].truncate(test_input[1]) == expected
+
+
+@given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))
+def test_truncate_equivalent_to_scale(x: Vector2, max_length: float):
+    """Vector2.scale_to and truncate are equivalent when max_length <= x.length"""
+    assume(max_length <= x.length)
+
+    scale    : Union[Vector2, Type[Exception]]
+    truncate : Union[Vector2, Type[Exception]]
+
+    try:
+        truncate = x.truncate(max_length)
+    except Exception as e:
+        truncate = type(e)
+
+    try:
+        scale = x.scale_to(max_length)
+    except Exception as e:
+        scale = type(e)
+
+    assert scale == truncate

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -11,13 +11,13 @@ def test_truncate_length(x: Vector2, max_length: float):
     assert x.truncate(max_length).length <= (1 + 1e-14) * max_length
 
 
-@given(x=vectors(), max_length=lengths())
+@given(x=vectors(), max_length=lengths(max_value=1e150))
 def test_truncate_invariant(x: Vector2, max_length: float):
     assume(x.length <= max_length)
     assert x.truncate(max_length) == x
 
 
-@given(x=vectors(), max_length=floats())
+@given(x=vectors(max_magnitude=1e150), max_length=floats())
 @example( # Large example where x.length == max_length but 1 * x != x
     x=Vector2(0.0, 7.1e+62), max_length=7.1e+62
 )

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -1,5 +1,5 @@
 import pytest  # type: ignore
-from hypothesis import assume, example, given
+from hypothesis import assume, example, given, note
 from hypothesis.strategies import floats
 from typing import Type, Union
 from utils import vectors
@@ -25,6 +25,9 @@ def test_truncate_invariant(x: Vector2, max_length: float):
 def test_truncate_equivalent_to_scale(x: Vector2, max_length: float):
     """Vector2.scale_to and truncate are equivalent when max_length <= x.length"""
     assume(max_length <= x.length)
+    note(f"x.length = {x.length}")
+    if max_length > 0:
+        note(f"x.length = {x.length / max_length} * max_length")
 
     scale    : Union[Vector2, Type[Exception]]
     truncate : Union[Vector2, Type[Exception]]

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -9,7 +9,7 @@ from ppb_vector import Vector2
 
 @given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))
 def test_truncate_length(x: Vector2, max_length: float):
-    assert x.truncate(max_length).length <= max_length
+    assert x.truncate(max_length).length <= (1 + 1e-14) * max_length
 
 
 @given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -1,5 +1,5 @@
 import pytest  # type: ignore
-from hypothesis import assume, given
+from hypothesis import assume, example, given
 from hypothesis.strategies import floats
 from typing import Type, Union
 from utils import vectors
@@ -19,6 +19,9 @@ def test_truncate_invariant(x: Vector2, max_length: float):
 
 
 @given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))
+@example( # Large example where x.length == max_length but 1 * x != x
+    x=Vector2(0.0, 7.387424005855793e+62), max_length=7.387424005855793e+62
+)
 def test_truncate_equivalent_to_scale(x: Vector2, max_length: float):
     """Vector2.scale_to and truncate are equivalent when max_length <= x.length"""
     assume(max_length <= x.length)

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -14,18 +14,6 @@ def test_truncate():
     assert test_vector_truncated == Vector2(4.068667356033675, 2.906190968595482)
 
 
-def test_truncate_larger_max_length():
-    vector = Vector2(3, 5)
-    truncated = vector.truncate(10)
-    assert vector == truncated
-
-
-def test_truncate_equal_max_length():
-    vector = Vector2(3, 4)
-    truncated = vector.truncate(5)
-    assert vector == truncated
-
-
 def test_truncate_lesser_max_length():
     vector = Vector2(20, 30)
     truncated = vector.truncate(10)
@@ -33,13 +21,9 @@ def test_truncate_lesser_max_length():
 
 
 data = [
-    ([Vector2(1, 2), 3], Vector2(1, 2)),
     ([Vector2(5, 12), 6], Vector2(5, 12).scale(6)),
     ([Vector2(92, 19), 61], Vector2(92, 19).scale(61)),
-    ([Vector2(22, 5), 41], Vector2(22, 5)),
     ([Vector2(2212481, 189898), 129039], Vector2(2212481, 189898).scale(129039)),
-    ([Vector2(5, 12), 13], Vector2(5, 12)),
-    ([Vector2(438, 153), 464], Vector2(438, 153)),
     ([Vector2(155, 155), 155], Vector2(155, 155).scale(155))
 ]
 
@@ -52,6 +36,12 @@ def test_multiples_values(test_input, expected):
 @given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))
 def test_truncate_length(x: Vector2, max_length: float):
     assert x.truncate(max_length).length <= max_length
+
+
+@given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))
+def test_truncate_invariant(x: Vector2, max_length: float):
+    assume(x.length <= max_length)
+    assert x.truncate(max_length) == x
 
 
 @given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -42,4 +42,9 @@ def test_truncate_equivalent_to_scale(x: Vector2, max_length: float):
     except Exception as e:
         scale = type(e)
 
-    assert scale == truncate
+    if isinstance(scale, Vector2) and x.length == max_length:
+        # Permit some edge-case where truncation and scaling aren't equivalent
+        assert scale.isclose(truncate, abs_tol=0, rel_tol=1e-12)
+
+    else:
+        assert scale == truncate

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -50,6 +50,11 @@ def test_multiples_values(test_input, expected):
 
 
 @given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))
+def test_truncate_length(x: Vector2, max_length: float):
+    assert x.truncate(max_length).length <= max_length
+
+
+@given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))
 def test_truncate_equivalent_to_scale(x: Vector2, max_length: float):
     """Vector2.scale_to and truncate are equivalent when max_length <= x.length"""
     assume(max_length <= x.length)

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -7,13 +7,6 @@ from utils import vectors
 from ppb_vector import Vector2
 
 
-def test_truncate():
-    test_vector = Vector2(700, 500)
-    test_vector_truncated = test_vector.truncate(5)
-    print(test_vector_truncated)
-    assert test_vector_truncated == Vector2(4.068667356033675, 2.906190968595482)
-
-
 @given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))
 def test_truncate_length(x: Vector2, max_length: float):
     assert x.truncate(max_length).length <= max_length

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -43,6 +43,7 @@ def test_truncate_equivalent_to_scale(x: Vector2, max_length: float):
 
     if isinstance(scale, Vector2) and x.length == max_length:
         # Permit some edge-case where truncation and scaling aren't equivalent
+        assert isinstance(truncate, Vector2)
         assert scale.isclose(truncate, abs_tol=0, rel_tol=1e-12)
 
     else:

--- a/tests/test_vector2_truncate.py
+++ b/tests/test_vector2_truncate.py
@@ -14,25 +14,6 @@ def test_truncate():
     assert test_vector_truncated == Vector2(4.068667356033675, 2.906190968595482)
 
 
-def test_truncate_lesser_max_length():
-    vector = Vector2(20, 30)
-    truncated = vector.truncate(10)
-    assert truncated == vector.scale(10)
-
-
-data = [
-    ([Vector2(5, 12), 6], Vector2(5, 12).scale(6)),
-    ([Vector2(92, 19), 61], Vector2(92, 19).scale(61)),
-    ([Vector2(2212481, 189898), 129039], Vector2(2212481, 189898).scale(129039)),
-    ([Vector2(155, 155), 155], Vector2(155, 155).scale(155))
-]
-
-
-@pytest.mark.parametrize('test_input, expected', data)
-def test_multiples_values(test_input, expected):
-    assert test_input[0].truncate(test_input[1]) == expected
-
-
 @given(x=vectors(max_magnitude=1e75), max_length=floats(min_value=0, max_value=1e75))
 def test_truncate_length(x: Vector2, max_length: float):
     assert x.truncate(max_length).length <= max_length

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,8 +8,8 @@ def angles():
 def floats(max_magnitude=1e75):
     return st.floats(min_value=-max_magnitude, max_value=max_magnitude)
 
-def lengths():
-    return st.floats(min_value=0, max_value=1e75)
+def lengths(min_value=0, max_value=1e75):
+    return st.floats(min_value=min_value, max_value=max_value)
 
 def vectors(max_magnitude=1e75):
     return st.builds(Vector2,


### PR DESCRIPTION
While working on #85, I noticed that `test_scale_to_equivalent_to_truncate` was broken (it had `min_value == max_value` for the length argument), so I had to go and fix it; while I was at it, I added some more tests.

There are a few behaviours that currently make the tests fail, that should be clarified:
- [x] `test_truncate_equivalent_to_scale` detects that `x.truncate(0)` always succeeds, whereas `x.scale_to(0)` fails when `x` is null.
  Should we make scaling the null vector to length 0 succeed, or should `truncate` raise an exception?
- [x] `test_truncate_length` detects that sometimes `scale_to` rounds up, resulting in a vector slightly-longer than the desired length.
  Should we make the test more lax (for instance, checking `length <= (1 + 1e-9) * max_length`) or should `truncate` make really sure that the resulting vector isn't larger than `max_length`?