### PR TITLE
Use consistent strategies for tests

### DIFF
--- a/tests/test_vector2_angle.py
+++ b/tests/test_vector2_angle.py
@@ -47,7 +47,7 @@ def test_angle_additive(left, middle, right):
     assert angle_isclose(lm + mr, lr)
 
 @given(
-    x=vectors(max_magnitude=1e150),
+    x=vectors(),
     l=floats(min_value=-1e150, max_value=1e150),
 )
 def test_angle_aligned(x: Vector2, l: float):

--- a/tests/test_vector2_angle.py
+++ b/tests/test_vector2_angle.py
@@ -2,8 +2,7 @@ from ppb_vector import Vector2
 from math import isclose
 import pytest  # type: ignore
 from hypothesis import assume, given, note
-from hypothesis.strategies import floats
-from utils import angle_isclose, vectors
+from utils import angle_isclose, floats, vectors
 
 
 @pytest.mark.parametrize("left, right, expected", [
@@ -46,10 +45,7 @@ def test_angle_additive(left, middle, right):
     lr = left.angle(right)
     assert angle_isclose(lm + mr, lr)
 
-@given(
-    x=vectors(),
-    l=floats(min_value=-1e150, max_value=1e150),
-)
+@given(x=vectors(), l=floats())
 def test_angle_aligned(x: Vector2, l: float):
     assume(l != 0)
     y = l * x

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -1,5 +1,5 @@
 from ppb_vector import Vector2
-from utils import angle_isclose, floats, vectors
+from utils import angle_isclose, angles, floats, vectors
 import pytest  # type: ignore
 import math
 from hypothesis import assume, given, note, example
@@ -37,17 +37,14 @@ def test_for_exception():
         Vector2('gibberish', 1).rotate(180)
 
 
-@given(angle=st.floats(min_value=-360, max_value=360))
+@given(angle=angles())
 def test_trig_stability(angle):
     r_cos, r_sin = Vector2._trig(angle)
     # Don't use exponents here. Multiplication is generally more stable.
     assert math.isclose(r_cos * r_cos + r_sin * r_sin, 1, rel_tol=1e-18)
 
 
-@given(
-    initial=vectors(),
-    angle=st.floats(min_value=-360, max_value=360),
-)
+@given(initial=vectors(), angle=angles())
 def test_rotation_angle(initial, angle):
     assume(initial.length > 1e-5)
     rotated = initial.rotate(angle)
@@ -59,10 +56,7 @@ def test_rotation_angle(initial, angle):
     assert angle_isclose(angle, measured_angle)
 
 
-@given(
-    increment=st.floats(min_value=1e-3, max_value=360),
-    loops=st.integers(min_value=0, max_value=500)
-)
+@given(increment=angles(), loops=st.integers(min_value=0, max_value=500))
 def test_rotation_stability(increment, loops):
     initial = Vector2(1, 0)
 
@@ -80,7 +74,7 @@ def test_rotation_stability(increment, loops):
 
 @given(
     initial=vectors(),
-    angles=st.lists(st.floats(min_value=-360, max_value=360)),
+    angles=st.lists(angles()),
 )
 def test_rotation_stability2(initial, angles):
     total_angle = sum(angles)
@@ -96,10 +90,7 @@ def test_rotation_stability2(initial, angles):
     assert math.isclose(fellswoop.length, initial.length, rel_tol=1e-15)
 
 
-@given(
-    a=vectors(), b=vectors(),
-    l=floats(), angle=st.floats(min_value=-360, max_value=360),
-)
+@given(a=vectors(), b=vectors(), l=floats(), angle=angles())
 # In this example:
 # * a * l == -b
 # * Rotation must not be an multiple of 90deg

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -1,5 +1,5 @@
 from ppb_vector import Vector2
-from utils import angle_isclose, vectors
+from utils import angle_isclose, floats, vectors
 import pytest  # type: ignore
 import math
 from hypothesis import assume, given, note, example
@@ -98,8 +98,7 @@ def test_rotation_stability2(initial, angles):
 
 @given(
     a=vectors(), b=vectors(),
-    l=st.floats(min_value=-1e150, max_value=1e150),
-    angle=st.floats(min_value=-360, max_value=360),
+    l=floats(), angle=st.floats(min_value=-360, max_value=360),
 )
 # In this example:
 # * a * l == -b

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -97,7 +97,7 @@ def test_rotation_stability2(initial, angles):
 
 
 @given(
-    a=vectors(max_magnitude=1e150), b=vectors(),
+    a=vectors(), b=vectors(),
     l=st.floats(min_value=-1e150, max_value=1e150),
     angle=st.floats(min_value=-360, max_value=360),
 )

--- a/tests/test_vector2_scalar_multiplication.py
+++ b/tests/test_vector2_scalar_multiplication.py
@@ -1,8 +1,7 @@
 import pytest  # type: ignore
 from hypothesis import assume, given
-from hypothesis.strategies import floats
 from math import isclose
-from utils import vectors
+from utils import floats, vectors
 
 from ppb_vector import Vector2
 
@@ -18,29 +17,22 @@ def test_scalar_multiplication(x, y, expected):
     assert x * y == expected
 
 
-@given(
-    x=floats(min_value=-1e75, max_value=1e75),
-    y=floats(min_value=-1e75, max_value=1e75),
-    v=vectors()
-)
+@given(x=floats(), y=floats(), v=vectors())
 def test_scalar_associative(x: float, y: float, v: Vector2):
     left  = (x * y) * v
     right =  x * (y * v)
     assert left.isclose(right)
 
-@given(
-    l=floats(min_value=-1e75, max_value=1e75),
-    x=vectors(), y=vectors(),
-)
+@given(l=floats(), x=vectors(), y=vectors())
 def test_scalar_linear(l: float, x: Vector2, y: Vector2):
     assert (l * (x + y)).isclose(l*x + l*y, rel_to=[x, y, l*x, l*y])
 
-@given(l=floats(min_value=-1e150, max_value=1e150), x=vectors())
+@given(l=floats(), x=vectors())
 def test_scalar_length(l: float, x: Vector2):
     assert isclose((l * x).length, abs(l) * x.length)
 
 
-@given(x=vectors(), l=floats(min_value=-1e150, max_value=1e150))
+@given(x=vectors(), l=floats())
 def test_scalar_division(x: Vector2, l: float):
     """Test that (x / λ) = (1 / λ) * x"""
     assume(abs(l) > 1e-100)

--- a/tests/test_vector2_scalar_multiplication.py
+++ b/tests/test_vector2_scalar_multiplication.py
@@ -21,7 +21,7 @@ def test_scalar_multiplication(x, y, expected):
 @given(
     x=floats(min_value=-1e75, max_value=1e75),
     y=floats(min_value=-1e75, max_value=1e75),
-    v=vectors(max_magnitude=1e150)
+    v=vectors()
 )
 def test_scalar_associative(x: float, y: float, v: Vector2):
     left  = (x * y) * v
@@ -30,16 +30,12 @@ def test_scalar_associative(x: float, y: float, v: Vector2):
 
 @given(
     l=floats(min_value=-1e75, max_value=1e75),
-    x=vectors(max_magnitude=1e75),
-    y=vectors(max_magnitude=1e75),
+    x=vectors(), y=vectors(),
 )
 def test_scalar_linear(l: float, x: Vector2, y: Vector2):
     assert (l * (x + y)).isclose(l*x + l*y, rel_to=[x, y, l*x, l*y])
 
-@given(
-    l=floats(min_value=-1e150, max_value=1e150),
-    x=vectors(max_magnitude=1e150),
-)
+@given(l=floats(min_value=-1e150, max_value=1e150), x=vectors())
 def test_scalar_length(l: float, x: Vector2):
     assert isclose((l * x).length, abs(l) * x.length)
 

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -7,7 +7,7 @@ from utils import vectors
 from ppb_vector import Vector2
 
 
-@given(x=vectors(max_magnitude=1e75), l=floats(min_value=-1e75, max_value=1e75))
+@given(x=vectors(), l=floats(min_value=-1e75, max_value=1e75))
 def test_scale_to_length(x: Vector2, l: float):
     """Test that the length of x.scale_to(l) is l."""
     try:
@@ -18,7 +18,7 @@ def test_scale_to_length(x: Vector2, l: float):
         assert l < 0
 
 
-@given(x=vectors(max_magnitude=1e75), l=floats(min_value=1e75, max_value=1e75))
+@given(x=vectors(), l=floats(min_value=1e75, max_value=1e75))
 def test_scale_is_equivalent_to_truncate(x: Vector2, l: float):
     """
     Vector2.scale_to is equivalent to Vector2.truncate

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -15,13 +15,3 @@ def test_scale_to_length(x: Vector2, l: float):
         assert x == (0, 0)
     except ValueError:
         assert l < 0
-
-
-@given(x=vectors(), l=lengths())
-def test_scale_is_equivalent_to_truncate(x: Vector2, l: float):
-    """
-    Vector2.scale_to is equivalent to Vector2.truncate
-    when the scalar is less than length
-    """
-    assume(0 < l <= x.length)
-    assert x.scale_to(l) == x.truncate(l)

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -1,8 +1,7 @@
 import pytest  # type: ignore
 from hypothesis import assume, given
-from hypothesis import strategies as st
 from math import isclose
-from utils import floats, vectors
+from utils import floats, lengths, vectors
 
 from ppb_vector import Vector2
 
@@ -18,11 +17,11 @@ def test_scale_to_length(x: Vector2, l: float):
         assert l < 0
 
 
-@given(x=vectors(), l=st.floats(min_value=1e75, max_value=1e75))
+@given(x=vectors(), l=lengths())
 def test_scale_is_equivalent_to_truncate(x: Vector2, l: float):
     """
     Vector2.scale_to is equivalent to Vector2.truncate
     when the scalar is less than length
     """
-    assume(l <= x.length)
+    assume(0 < l <= x.length)
     assert x.scale_to(l) == x.truncate(l)

--- a/tests/test_vector2_scale.py
+++ b/tests/test_vector2_scale.py
@@ -1,13 +1,13 @@
 import pytest  # type: ignore
 from hypothesis import assume, given
-from hypothesis.strategies import floats
+from hypothesis import strategies as st
 from math import isclose
-from utils import vectors
+from utils import floats, vectors
 
 from ppb_vector import Vector2
 
 
-@given(x=vectors(), l=floats(min_value=-1e75, max_value=1e75))
+@given(x=vectors(), l=floats())
 def test_scale_to_length(x: Vector2, l: float):
     """Test that the length of x.scale_to(l) is l."""
     try:
@@ -18,7 +18,7 @@ def test_scale_to_length(x: Vector2, l: float):
         assert l < 0
 
 
-@given(x=vectors(), l=floats(min_value=1e75, max_value=1e75))
+@given(x=vectors(), l=st.floats(min_value=1e75, max_value=1e75))
 def test_scale_is_equivalent_to_truncate(x: Vector2, l: float):
     """
     Vector2.scale_to is equivalent to Vector2.truncate

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ from ppb_vector import Vector2
 import hypothesis.strategies as st
 
 
-def vectors(max_magnitude=1e300):
+def vectors(max_magnitude=1e75):
     return st.builds(Vector2,
                      st.floats(min_value=-max_magnitude, max_value=max_magnitude),
                      st.floats(min_value=-max_magnitude, max_value=max_magnitude)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,9 @@ from ppb_vector import Vector2
 import hypothesis.strategies as st
 
 
+def floats(max_magnitude=1e75):
+    return st.floats(min_value=-max_magnitude, max_value=max_magnitude)
+
 def vectors(max_magnitude=1e75):
     return st.builds(Vector2,
                      st.floats(min_value=-max_magnitude, max_value=max_magnitude),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,9 @@ from ppb_vector import Vector2
 import hypothesis.strategies as st
 
 
+def angles():
+    return st.floats(min_value=-360, max_value=360)
+
 def floats(max_magnitude=1e75):
     return st.floats(min_value=-max_magnitude, max_value=max_magnitude)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,10 +17,8 @@ def vectors(max_magnitude=1e75):
                      st.floats(min_value=-max_magnitude, max_value=max_magnitude)
     )
 
-@st.composite
-def units(draw, elements=st.floats(min_value=0, max_value=360)):
-    angle = draw(elements)
-    return Vector2(1, 0).rotate(angle)
+def units():
+    return st.builds(Vector2(1, 0).rotate, angles())
 
 
 def angle_isclose(x, y, epsilon = 6.5e-5):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,9 @@ def angles():
 def floats(max_magnitude=1e75):
     return st.floats(min_value=-max_magnitude, max_value=max_magnitude)
 
+def lengths():
+    return st.floats(min_value=0, max_value=1e75)
+
 def vectors(max_magnitude=1e75):
     return st.builds(Vector2,
                      st.floats(min_value=-max_magnitude, max_value=max_magnitude),


### PR DESCRIPTION
- [x] `utils.vectors`: Set the default `max_magnitude` to 10⁷⁵.
  No test uses a smaller value, and larger vectors are meaningless: the observable Universe is 9×10²⁶ meters across...
- [x] Introduce convenience strategies for `angles` and `lengths`.
  This should make it more obvious which inputs are what, and that should help with #85.
- [x] Simplify `utils.units`.