### PR TITLE
Add tests for dot product

### DIFF
--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -1,9 +1,9 @@
 from ppb_vector import Vector2
 
-from math import isclose, sqrt
+from math import sqrt
 import pytest  # type: ignore
 from hypothesis import assume, given, note
-from utils import floats, vectors
+from utils import floats, isclose, vectors
 
 
 @given(x=vectors(), y=vectors())
@@ -24,4 +24,4 @@ def test_dot_linear(x: Vector2, y: Vector2, z: Vector2, scalar: float):
     inner, outer = x * (scalar * y + z), scalar * x * y + x * z
     note(f"inner: {inner}")
     note(f"outer: {outer}")
-    assert isclose(inner, outer, abs_tol=1e-5, rel_tol=1e-5)
+    assert isclose(inner, outer, rel_tol=1e-5, rel_to=(x, scalar, y, z))

--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -19,6 +19,11 @@ def test_dot_commutes(x: Vector2, y: Vector2):
 def test_dot_length(x: Vector2):
     assert isclose(x * x, x.length * x.length)
 
+@given(x=vectors(), y=vectors())
+def test_cauchy_schwarz(x: Vector2, y: Vector2):
+    """Test the Cauchy-Schwarz inequality: |x·y| ⩽ |x| |y|"""
+    assert abs(x * y) <= (1 + 1e-12) * x.length * y.length
+
 @given(x=vectors(), y=vectors(), angle=angles())
 def test_dot_rotational_invariance(x: Vector2, y: Vector2, angle: float):
     """Test that rotating vectors doesn't change their dot product."""

--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -25,3 +25,22 @@ def test_dot_linear(x: Vector2, y: Vector2, z: Vector2, scalar: float):
     note(f"inner: {inner}")
     note(f"outer: {outer}")
     assert isclose(inner, outer, rel_tol=1e-5, rel_to=(x, scalar, y, z))
+
+
+@given(x=vectors(max_magnitude=1e7), y=vectors(max_magnitude=1e7))
+def test_dot_from_angle(x: Vector2, y: Vector2):
+    """Test x · y == |x| · |y| · cos(θ)"""
+    t = x.angle(y)
+    cos_t, _ = Vector2._trig(t)
+
+    # Dismiss near-othogonal test inputs
+    assume(abs(cos_t) > 1e-6)
+
+    min_len, max_len = sorted((x.length, y.length))
+    geometric = min_len * (max_len * cos_t)
+
+    note(f"θ: {t}")
+    note(f"cos θ: {cos_t}")
+    note(f"algebraic: {x * y}")
+    note(f"geometric: {geometric}")
+    assert isclose(x * y, geometric, abs_tol=1e-2, rel_tol=1e-4, rel_to=(x, y))

--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -55,4 +55,4 @@ def test_dot_from_angle(x: Vector2, y: Vector2):
     note(f"cos θ: {cos_t}")
     note(f"algebraic: {x * y}")
     note(f"geometric: {geometric}")
-    assert isclose(x * y, geometric, abs_tol=1e-2, rel_tol=1e-4, rel_to=(x, y))
+    assert isclose(x * y, geometric, abs_tol=1e-5, rel_tol=1e-5, rel_to=(x, y))

--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -1,0 +1,23 @@
+from ppb_vector import Vector2
+
+from math import isclose, sqrt
+import pytest  # type: ignore
+from hypothesis import assume, given, note
+from utils import floats, vectors
+
+
+@given(x=vectors(), y=vectors())
+def test_dot_commutes(x: Vector2, y: Vector2):
+    assert x * y == y * x
+
+
+MAGNITUDE=1e10
+@given(x=vectors(max_magnitude=MAGNITUDE), z=vectors(max_magnitude=MAGNITUDE),
+       y=vectors(max_magnitude=sqrt(MAGNITUDE)),
+       scalar=floats(max_magnitude=sqrt(MAGNITUDE)))
+def test_dot_linear(x: Vector2, y: Vector2, z: Vector2, scalar: float):
+    """Test that x · (λ y + z) = λ x·y + x·z"""
+    inner, outer = x * (scalar * y + z), scalar * x * y + x * z
+    note(f"inner: {inner}")
+    note(f"outer: {outer}")
+    assert isclose(inner, outer, abs_tol=1e-5, rel_tol=1e-5)

--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -3,7 +3,7 @@ from ppb_vector import Vector2
 from math import sqrt
 import pytest  # type: ignore
 from hypothesis import assume, given, note
-from utils import floats, isclose, vectors
+from utils import angles, floats, isclose, vectors
 
 
 @given(x=vectors(), y=vectors())
@@ -13,6 +13,18 @@ def test_dot_commutes(x: Vector2, y: Vector2):
 @given(x=vectors())
 def test_dot_length(x: Vector2):
     assert isclose(x * x, x.length * x.length)
+
+@given(x=vectors(), y=vectors(), angle=angles())
+def test_dot_rotational_invariance(x: Vector2, y: Vector2, angle: float):
+    """Test that rotating vectors doesn't change their dot product."""
+    t = x.angle(y)
+    cos_t, _ = Vector2._trig(t)
+    note(f"θ: {t}")
+    note(f"cos θ: {cos_t}")
+
+    # Exclude near-orthogonal test inputs
+    assume(abs(cos_t) > 1e-6)
+    assert isclose(x * y, x.rotate(angle) * y.rotate(angle), rel_to=(x, y))
 
 
 MAGNITUDE=1e10

--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -6,6 +6,11 @@ from hypothesis import assume, given, note
 from utils import angles, floats, isclose, vectors
 
 
+@given(vector=vectors())
+def test_dot_axis(vector: Vector2):
+    assert vector * (1, 0) == vector.x
+    assert vector * (0, 1) == vector.y
+
 @given(x=vectors(), y=vectors())
 def test_dot_commutes(x: Vector2, y: Vector2):
     assert x * y == y * x

--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -10,6 +10,10 @@ from utils import floats, vectors
 def test_dot_commutes(x: Vector2, y: Vector2):
     assert x * y == y * x
 
+@given(x=vectors())
+def test_dot_length(x: Vector2):
+    assert isclose(x * x, x.length * x.length)
+
 
 MAGNITUDE=1e10
 @given(x=vectors(max_magnitude=MAGNITUDE), z=vectors(max_magnitude=MAGNITUDE),

--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -29,7 +29,8 @@ def test_dot_rotational_invariance(x: Vector2, y: Vector2, angle: float):
 
     # Exclude near-orthogonal test inputs
     assume(abs(cos_t) > 1e-6)
-    assert isclose(x * y, x.rotate(angle) * y.rotate(angle), rel_to=(x, y))
+    assert isclose(x * y, x.rotate(angle) * y.rotate(angle),
+                   rel_to=(x, y), rel_exp=2)
 
 
 MAGNITUDE=1e10
@@ -41,7 +42,7 @@ def test_dot_linear(x: Vector2, y: Vector2, z: Vector2, scalar: float):
     inner, outer = x * (scalar * y + z), scalar * x * y + x * z
     note(f"inner: {inner}")
     note(f"outer: {outer}")
-    assert isclose(inner, outer, rel_tol=1e-5, rel_to=(x, scalar, y, z))
+    assert isclose(inner, outer, rel_tol=1e-5, rel_to=(x, scalar, y, z), rel_exp=2)
 
 
 @given(x=vectors(max_magnitude=1e7), y=vectors(max_magnitude=1e7))
@@ -60,4 +61,5 @@ def test_dot_from_angle(x: Vector2, y: Vector2):
     note(f"cos θ: {cos_t}")
     note(f"algebraic: {x * y}")
     note(f"geometric: {geometric}")
-    assert isclose(x * y, geometric, abs_tol=1e-5, rel_tol=1e-5, rel_to=(x, y))
+    assert isclose(x * y, geometric, abs_tol=1e-5,
+                   rel_tol=1e-5, rel_to=(x, y), rel_exp=2)

--- a/tests/test_vector2_dot.py
+++ b/tests/test_vector2_dot.py
@@ -42,7 +42,7 @@ def test_dot_linear(x: Vector2, y: Vector2, z: Vector2, scalar: float):
     inner, outer = x * (scalar * y + z), scalar * x * y + x * z
     note(f"inner: {inner}")
     note(f"outer: {outer}")
-    assert isclose(inner, outer, rel_tol=1e-5, rel_to=(x, scalar, y, z), rel_exp=2)
+    assert isclose(inner, outer, rel_to=(x, scalar, y, z), rel_exp=2)
 
 
 @given(x=vectors(max_magnitude=1e7), y=vectors(max_magnitude=1e7))
@@ -61,5 +61,4 @@ def test_dot_from_angle(x: Vector2, y: Vector2):
     note(f"cos θ: {cos_t}")
     note(f"algebraic: {x * y}")
     note(f"geometric: {geometric}")
-    assert isclose(x * y, geometric, abs_tol=1e-5,
-                   rel_tol=1e-5, rel_to=(x, y), rel_exp=2)
+    assert isclose(x * y, geometric, rel_to=(x, y), rel_exp=2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
 from ppb_vector import Vector2
+from hypothesis import note
+from typing import Sequence, Union
 import hypothesis.strategies as st
 
 
@@ -24,6 +26,21 @@ def units():
 def angle_isclose(x, y, epsilon = 6.5e-5):
     d = (x - y) % 360
     return (d < epsilon) or (d > 360 - epsilon)
+
+def isclose(x, y, abs_tol: float=1e-9, rel_tol: float=1e-9,
+            rel_to: Sequence[Union[float, Vector2]]=[]):
+    diff = abs(x - y)
+    rel_max = max(abs(x), abs(y),
+                  *(abs(z) for z in rel_to if isinstance(z, float)),
+                  *(z.length for z in rel_to if isinstance(z, Vector2))
+    )
+    note(f"rel_max = {rel_max}")
+    if rel_max > 0:
+        note(f"diff = {diff} = {diff/rel_max} * rel_max")
+    else:
+        note(f"diff = {diff}")
+
+    return diff <= rel_max * rel_tol or diff <= abs_tol
 
 
 # List of operations that (Vector2, Vector2) -> Vector2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,12 +27,15 @@ def angle_isclose(x, y, epsilon = 6.5e-5):
     d = (x - y) % 360
     return (d < epsilon) or (d > 360 - epsilon)
 
-def isclose(x, y, abs_tol: float=1e-9, rel_tol: float=1e-9,
+def isclose(x, y, abs_tol: float=1e-9, rel_tol: float=1e-9, rel_exp: float=1,
             rel_to: Sequence[Union[float, Vector2]]=[]):
+    if rel_exp < 1:
+        raise ValueError(f"Expected rel_exp >= 1, got {rel_exp}")
+
     diff = abs(x - y)
     rel_max = max(abs(x), abs(y),
-                  *(abs(z) for z in rel_to if isinstance(z, float)),
-                  *(z.length for z in rel_to if isinstance(z, Vector2))
+                  *(abs(z) ** rel_exp for z in rel_to if isinstance(z, float)),
+                  *(z.length ** rel_exp for z in rel_to if isinstance(z, Vector2))
     )
     note(f"rel_max = {rel_max}")
     if rel_max > 0:


### PR DESCRIPTION
- [x] Test commutativity and linearity.
- [x] Test coordinate extraction (i.e. `vector * (1, 0) == vector.x`)
- [x] Test relationship to vector length.
- [x] Test against the geometric interpretation of dot product.
- [x] Test invariance under rotation.

Closes #9 