### PR TITLE
Make the tests for isclose less flaky

### DIFF
--- a/tests/test_vector2_isclose.py
+++ b/tests/test_vector2_isclose.py
@@ -37,6 +37,8 @@ def test_isclose_abs_error(x, direction, abs_tol):
 
 @given(x=vectors(max_magnitude=1e30), direction=units(),
        rel_tol=floats(min_value=EPSILON, max_value=1-sqrt(EPSILON)))
+@example(x=Vector2(0.5030575955800033, 4183.540331936798), direction=Vector2(-0.21080691603913568, -0.97752772039982), rel_tol=1.0000044626502047e-08)
+@example(x=Vector2(0.336348726648339, 4183.540331936798), direction=Vector2(-0.2108069159366941, -0.9775277204219119), rel_tol=1.0000009102918328e-08)
 def test_isclose_rel_error(x, direction, rel_tol):
     """Test x.isclose(abs_tol=0) near the boundary between “close” and “not close”
 

--- a/tests/test_vector2_isclose.py
+++ b/tests/test_vector2_isclose.py
@@ -17,22 +17,20 @@ EPSILON = 1e-8
 def test_isclose_abs_error(x, direction, abs_tol):
     """Test x.isclose(rel_tol=0) near the boundary between “close” and “not close”
 
-    - x + (1 - ε) * abs_tol * direction should always be close
-    - x + (1 + ε) * abs_tol * direction should not be close
-      assuming it isn't equal to x (because of rounding, or because x is null)
+    - x + (1 - ε) * abs_tol * direction should be close
+    - x + (1 + ε) * abs_tol * direction shouldn't be close
     """
-    error = abs_tol * direction
-    note(f"error = {error}")
+    assume(abs_tol > EPSILON * x.length)
+    note(f"|x|: {x.length}")
 
+    error = abs_tol * direction
     positive = x + (1 - sqrt(EPSILON)) * error
     note(f"positive example: {positive} = x + {positive - x}")
     assert x.isclose(positive, abs_tol=abs_tol, rel_tol=0)
 
-    if abs_tol > EPSILON * x.length:
-        negative = x + (1 + sqrt(EPSILON)) * error
-        event("Negative example generated (abs_tol > ε * |x|)")
-        note(f"negative example: {negative} = x + {negative - x}")
-        assert not x.isclose(negative, abs_tol=abs_tol, rel_tol=0)
+    negative = x + (1 + sqrt(EPSILON)) * abs_tol * direction
+    note(f"negative example: {negative} = x + {negative - x}")
+    assert not x.isclose(negative, abs_tol=abs_tol, rel_tol=0)
 
 
 @given(x=vectors(max_magnitude=1e30), direction=units(),

--- a/tests/test_vector2_isclose.py
+++ b/tests/test_vector2_isclose.py
@@ -13,7 +13,8 @@ def test_isclose_to_self(x, abs_tol, rel_tol):
 
 EPSILON = 1e-8
 
-@given(x=vectors(), direction=units(), abs_tol=lengths())
+@given(x=vectors(max_magnitude=1e30), direction=units(),
+       abs_tol=lengths(max_value=1e30))
 def test_isclose_abs_error(x, direction, abs_tol):
     """Test x.isclose(rel_tol=0) near the boundary between “close” and “not close”
 

--- a/tests/test_vector2_isclose.py
+++ b/tests/test_vector2_isclose.py
@@ -1,5 +1,6 @@
 from ppb_vector import Vector2
 from pytest import raises # type: ignore
+from math import sqrt
 from utils import units, lengths, vectors
 from hypothesis import assume, event, given, note, example
 from hypothesis.strategies import floats
@@ -16,26 +17,26 @@ EPSILON = 1e-8
 def test_isclose_abs_error(x, direction, abs_tol):
     """Test x.isclose(rel_tol=0) near the boundary between “close” and “not close”
 
-    - x + (1 - EPSILON) * abs_tol * direction should always be close
-    - x + (1 + EPSILON) * abs_tol * direction should not be close
+    - x + (1 - ε) * abs_tol * direction should always be close
+    - x + (1 + ε) * abs_tol * direction should not be close
       assuming it isn't equal to x (because of rounding, or because x is null)
     """
     error = abs_tol * direction
     note(f"error = {error}")
 
-    positive = x + (1 - EPSILON) * error
+    positive = x + (1 - sqrt(EPSILON)) * error
     note(f"positive example: {positive} = x + {positive - x}")
     assert x.isclose(positive, abs_tol=abs_tol, rel_tol=0)
 
     if abs_tol > EPSILON * x.length:
-        negative = x + (1 + EPSILON) * error
+        negative = x + (1 + sqrt(EPSILON)) * error
         event("Negative example generated (abs_tol > ε * |x|)")
         note(f"negative example: {negative} = x + {negative - x}")
         assert not x.isclose(negative, abs_tol=abs_tol, rel_tol=0)
 
 
 @given(x=vectors(max_magnitude=1e30), direction=units(),
-       rel_tol=floats(min_value=EPSILON, max_value=1-EPSILON))
+       rel_tol=floats(min_value=EPSILON, max_value=1-sqrt(EPSILON)))
 def test_isclose_rel_error(x, direction, rel_tol):
     """Test x.isclose(abs_tol=0) near the boundary between “close” and “not close”
 
@@ -46,7 +47,7 @@ def test_isclose_rel_error(x, direction, rel_tol):
     note(f"|x| = {x.length}")
     error = rel_tol * direction
 
-    positive = x + (1 - EPSILON) * x.length * error
+    positive = x + (1 - sqrt(EPSILON)) * x.length * error
     note(f"positive example: {positive} = x + {positive - x} ="
          f"x + {(positive - x).length / x.length} * |x| * direction")
 
@@ -63,7 +64,7 @@ def test_isclose_rel_error(x, direction, rel_tol):
     # δ > rel_tol * (|x| + δ) is suitable. The smallest is
     # rel_tol |x| / (1 - rel_tol), as such, we take
     # Δ = r * |x| * direction / (1 - rel_tol), and an ε safety margin.
-    negative = x + (1 + EPSILON) / (1 - rel_tol) * x.length * error
+    negative = x + (1 + sqrt(EPSILON)) / (1 - rel_tol) * x.length * error
     note(f"negative example: {negative} = x + {negative - x} = "
          f"x + {(negative - x).length / x.length} * |x| * direction")
 

--- a/tests/test_vector2_isclose.py
+++ b/tests/test_vector2_isclose.py
@@ -44,9 +44,9 @@ def test_isclose_rel_error(x, direction, rel_tol):
     """
     assume(x.length > EPSILON)
     note(f"|x| = {x.length}")
-    error = rel_tol * x.length * direction
+    error = rel_tol * direction
 
-    positive = x + (1 - EPSILON) * error
+    positive = x + (1 - EPSILON) * x.length * error
     note(f"positive example: {positive} = x + {positive - x} ="
          f"x + {(positive - x).length / x.length} * |x| * direction")
 
@@ -63,7 +63,7 @@ def test_isclose_rel_error(x, direction, rel_tol):
     # δ > rel_tol * (|x| + δ) is suitable. The smallest is
     # rel_tol |x| / (1 - rel_tol), as such, we take
     # Δ = r * |x| * direction / (1 - rel_tol), and an ε safety margin.
-    negative = x + (1 + EPSILON) / (1 - rel_tol) * error
+    negative = x + (1 + EPSILON) / (1 - rel_tol) * x.length * error
     note(f"negative example: {negative} = x + {negative - x} = "
          f"x + {(negative - x).length / x.length} * |x| * direction")
 

--- a/tests/test_vector2_isclose.py
+++ b/tests/test_vector2_isclose.py
@@ -39,9 +39,8 @@ def test_isclose_abs_error(x, direction, abs_tol):
 def test_isclose_rel_error(x, direction, rel_tol):
     """Test x.isclose(abs_tol=0) near the boundary between “close” and “not close”
 
-    - x + rel_tol * |x| * direction should always be close
-    - x + (1 + EPSILON) * rel_tol * |x| * direction should not be close
-      assuming it isn't equal to x (because of rounding, or because x is null)
+    - x + (1 - ε) * |x| * rel_tol * direction should always be close
+    - In many cases, we should be able to generate an example that isn't close
     """
     error = rel_tol * x.length * direction
     note(f"error = {error}")

--- a/tests/test_vector2_isclose.py
+++ b/tests/test_vector2_isclose.py
@@ -42,33 +42,32 @@ def test_isclose_rel_error(x, direction, rel_tol):
     - x + (1 - ε) * |x| * rel_tol * direction should always be close
     - In many cases, we should be able to generate an example that isn't close
     """
+    assume(x.length > EPSILON)
+    note(f"|x| = {x.length}")
     error = rel_tol * x.length * direction
-    note(f"error = {error}")
 
     positive = x + (1 - EPSILON) * error
-    note(f"positive example: {positive} = x + {positive - x}")
-    if x.length > EPSILON:
-        note(f"x + |x| * {(positive - x) / x.length}")
+    note(f"positive example: {positive} = x + {positive - x} ="
+         f"x + {(positive - x).length / x.length} * |x| * direction")
 
     assert x.isclose(positive, abs_tol=0, rel_tol=rel_tol)
 
-    if x.length > EPSILON:
-        # In x.isclose(negative), the allowed relative error is relative to |x|
-        # and |negative|, so the acceptable errors grow larger as negative does.
-        #
-        # The choice of negative accounts for this, with the (1 - rel_tol) term:
-        # we have negative = x + Δ, and we want to pick Δ such that
-        # δ = |x - negative| > rel_tol * max(|x|, |negative|)
-        #
-        # Since r * (|x| + δ) > rel_tol * max(|x|, |negative|), any choice where
-        # δ > rel_tol * (|x| + δ) is suitable. The smallest is
-        # rel_tol |x| / (1 - rel_tol), as such, we take
-        # Δ = r * |x| * direction / (1 - rel_tol), and an ε safety margin.
-        negative = x + (1 + EPSILON) / (1 - rel_tol) * error
-        note(f"negative example: {negative} = x + {negative - x} = "
-             f"x + {(negative - x).length / x.length} * |x| * {(negative - x).normalize()}")
+    # In x.isclose(negative), the allowed relative error is relative to |x|
+    # and |negative|, so the acceptable errors grow larger as negative does.
+    #
+    # The choice of negative accounts for this, with the (1 - rel_tol) term:
+    # we have negative = x + Δ, and we want to pick Δ such that
+    # δ = |x - negative| > rel_tol * max(|x|, |negative|)
+    #
+    # Since r * (|x| + δ) > rel_tol * max(|x|, |negative|), any choice where
+    # δ > rel_tol * (|x| + δ) is suitable. The smallest is
+    # rel_tol |x| / (1 - rel_tol), as such, we take
+    # Δ = r * |x| * direction / (1 - rel_tol), and an ε safety margin.
+    negative = x + (1 + EPSILON) / (1 - rel_tol) * error
+    note(f"negative example: {negative} = x + {negative - x} = "
+         f"x + {(negative - x).length / x.length} * |x| * direction")
 
-        assert not x.isclose(negative, abs_tol=0, rel_tol=rel_tol)
+    assert not x.isclose(negative, abs_tol=0, rel_tol=rel_tol)
 
 
 def test_isclose_negative_tolerances():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,8 +10,8 @@ def angles():
 def floats(max_magnitude=1e75):
     return st.floats(min_value=-max_magnitude, max_value=max_magnitude)
 
-def lengths():
-    return st.floats(min_value=0, max_value=1e75)
+def lengths(min_value=0, max_value=1e75):
+    return st.floats(min_value=min_value, max_value=max_value)
 
 def vectors(max_magnitude=1e75):
     return st.builds(Vector2,


### PR DESCRIPTION
I was able to run Hypothesis, in the CI profile, ~200~ 500 times in a row without encountering a single failure:
```
$ for i in {1..200}; pytest -v --hypothesis-profile ci tests/test_vector2_isclose.py || { echo $i ; break }
```