### PR TITLE
Implement the mapping protocol

### DIFF
--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -172,6 +172,9 @@ class Vector2:
         """Perform a division between a vector and a scalar."""
         return type(self)(self.x / other, self.y / other)
 
+    def keys(self: VectorOrSub) -> typing.Sequence[str]:
+        return ['x', 'y']
+
     def __getitem__(self: VectorOrSub, item: typing.Union[str, int]) -> Realish:
         if hasattr(item, '__index__'):
             item = item.__index__()  # type: ignore

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -60,7 +60,20 @@ class Vector2:
     x: float
     y: float
 
-    def __init__(self, x: typing.SupportsFloat, y: typing.SupportsFloat):
+    @typing.overload
+    def __init__(self, x: typing.SupportsFloat, y: typing.SupportsFloat): pass
+
+    @typing.overload
+    def __init__(self, other: VectorLike): pass
+
+    def __init__(self, *args):
+        if len(args) == 1:
+            x, y = Vector2.convert(args[0])
+        elif len(args) == 2:
+            x, y = args
+        else:
+            raise TypeError(f"Expected 1 vector-like or 2 float-like arguments, got {len(args)}")
+
         try:
             self.x = x.__float__()
         except AttributeError:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,10 +3,11 @@ import pytest  # type: ignore
 from ppb_vector import Vector2
 from utils import vector_likes
 
-@pytest.mark.parametrize('vector_like', vector_likes(), ids=lambda x: type(x).__name__) # type: ignore
-def test_convert_subclass(vector_like):
-    class V(Vector2): pass
+class V(Vector2): pass
 
-    vector = V.convert(vector_like)
-    assert isinstance(vector, V)
+@pytest.mark.parametrize('vector_like', vector_likes(), ids=lambda x: type(x).__name__) # type: ignore
+@pytest.mark.parametrize('cls', [Vector2, V]) # type: ignore
+def test_convert_class(cls, vector_like):
+    vector = cls.convert(vector_like)
+    assert isinstance(vector, cls)
     assert vector == vector_like

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -17,3 +17,7 @@ def test_convert_class(cls, vector_like):
 @given(vector=vectors())
 def test_convert_tuple(vector: Vector2):
     assert vector == tuple(vector) == (vector.x, vector.y)
+
+@given(vector=vectors())
+def test_convert_list(vector: Vector2):
+    assert vector == list(vector) == [vector.x, vector.y]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,7 +1,8 @@
 import pytest  # type: ignore
+from hypothesis import given
 
 from ppb_vector import Vector2
-from utils import vector_likes
+from utils import vector_likes, vectors
 
 class V(Vector2): pass
 
@@ -11,3 +12,8 @@ def test_convert_class(cls, vector_like):
     vector = cls.convert(vector_like)
     assert isinstance(vector, cls)
     assert vector == vector_like
+
+
+@given(vector=vectors())
+def test_convert_tuple(vector: Vector2):
+    assert vector == tuple(vector) == (vector.x, vector.y)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -21,3 +21,9 @@ def test_convert_tuple(vector: Vector2):
 @given(vector=vectors())
 def test_convert_list(vector: Vector2):
     assert vector == list(vector) == [vector.x, vector.y]
+
+
+@pytest.mark.parametrize('coerce', [tuple, list])
+@given(x=vectors())
+def test_convert_roundtrip(coerce, x: Vector2):
+    assert x == Vector2(coerce(x))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -7,5 +7,6 @@ from utils import vector_likes
 def test_convert_subclass(vector_like):
     class V(Vector2): pass
 
-    # test_binop_vectorlike already checks the output value is correct
-    assert isinstance(V.convert(vector_like), V)
+    vector = V.convert(vector_like)
+    assert isinstance(vector, V)
+    assert vector == vector_like

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -22,8 +22,12 @@ def test_convert_tuple(vector: Vector2):
 def test_convert_list(vector: Vector2):
     assert vector == list(vector) == [vector.x, vector.y]
 
+@given(vector=vectors())
+def test_convert_dict(vector: Vector2):
+    assert vector == dict(vector) == {'x': vector.x, 'y': vector.y}
 
-@pytest.mark.parametrize('coerce', [tuple, list])
+
+@pytest.mark.parametrize('coerce', [tuple, list, dict])
 @given(x=vectors())
 def test_convert_roundtrip(coerce, x: Vector2):
     assert x == Vector2(coerce(x))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,7 +3,7 @@ import pytest  # type: ignore
 from ppb_vector import Vector2
 from utils import vector_likes
 
-@pytest.mark.parametrize('vector_like', vector_likes()) # type: ignore
+@pytest.mark.parametrize('vector_like', vector_likes(), ids=lambda x: type(x).__name__) # type: ignore
 def test_convert_subclass(vector_like):
     class V(Vector2): pass
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,9 +1,9 @@
 import pytest  # type: ignore
 
 from ppb_vector import Vector2
-from utils import *
+from utils import vector_likes
 
-@pytest.mark.parametrize('vector_like', UNIT_VECTOR_LIKES) # type: ignore
+@pytest.mark.parametrize('vector_like', vector_likes()) # type: ignore
 def test_convert_subclass(vector_like):
     class V(Vector2): pass
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,5 +1,5 @@
 import pytest  # type: ignore
-from hypothesis import event, given, strategies as st
+from hypothesis import event, given, reject, strategies as st
 
 from ppb_vector import Vector2
 from utils import *
@@ -45,7 +45,7 @@ def test_vnumop(op, x: V1, scalar: float):
         assert isinstance(op(x, scalar), V1)
     except (ValueError, ZeroDivisionError) as e:
         event(type(e).__name__)
-        pass
+        reject()
 
 
 @pytest.mark.parametrize('op', UNARY_OPS)
@@ -55,7 +55,7 @@ def test_monop(op, x):
         assert isinstance(op(x), V1)
     except (ValueError, ZeroDivisionError) as e:
         event(type(e).__name__)
-        pass
+        reject()
 
 
 @pytest.mark.parametrize('op', BINARY_OPS + BINARY_SCALAR_OPS + BOOL_OPS) # type: ignore

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -59,7 +59,8 @@ def test_monop(op):
 def test_binop_vectorlike(op):
     """Test that `op` accepts a vector-like second parameter."""
     x = Vector2(1, 0)
-    result = op(x, Vector2(0, 1))
+    y = Vector2(0, 1)
+    result = op(x, y)
 
-    for y_like in UNIT_VECTOR_LIKES :
+    for y_like in vector_likes(y):
         assert op(x, y_like) == result

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -3,21 +3,30 @@ import pytest  # type: ignore
 from ppb_vector import Vector2
 from utils import *
 
+
+class V1(Vector2):
+    """Arbitrary subclass of Vector2."""
+    pass
+
+class V11(V1):
+    """Subclass of V1."""
+    pass
+
+class V2(Vector2):
+    """Arbitrary subclass of Vector2, distinct from V1."""
+    pass
+
+
 @pytest.mark.parametrize('op', BINARY_OPS)
 def test_binop_same(op):
-    class V(Vector2): pass
-
     # Normalize for reflect
-    a = op(V(1, 2), V(3, 4).normalize())
+    a = op(V1(1, 2), V1(3, 4).normalize())
 
-    assert isinstance(a, V)
+    assert isinstance(a, V1)
 
 
 @pytest.mark.parametrize('op', BINARY_OPS)
 def test_binop_different(op):
-    class V1(Vector2): pass
-    class V2(Vector2): pass
-
     # Normalize for reflect
     a = op(V1(1, 2), V2(3, 4).normalize())
     b = op(V2(1, 2), V1(3, 4).normalize())
@@ -27,32 +36,23 @@ def test_binop_different(op):
 
 @pytest.mark.parametrize('op', BINARY_OPS)
 def test_binop_subclass(op):
-    class V1(Vector2): pass
-    class V2(V1): pass
-
     # Normalize for reflect
-    a = op(V1(1, 2), V2(3, 4).normalize())
-    b = op(V2(1, 2), V1(3, 4).normalize())
-    assert isinstance(a, V2)
-    assert isinstance(b, V2)
+    a = op(V1(1, 2), V11(3, 4).normalize())
+    b = op(V11(1, 2), V1(3, 4).normalize())
+    assert isinstance(a, V11)
+    assert isinstance(b, V11)
 
 
 @pytest.mark.parametrize('op', SCALAR_OPS)
 def test_vnumop(op):
-    class V(Vector2): pass
-
-    a = op(V(1, 2), 42)
-
-    assert isinstance(a, V)
+    a = op(V1(1, 2), 42)
+    assert isinstance(a, V1)
 
 
 @pytest.mark.parametrize('op', UNARY_OPS)
 def test_monop(op):
-    class V(Vector2): pass
-
-    a = op(V(1, 2))
-
-    assert isinstance(a, V)
+    a = op(V1(1, 2))
+    assert isinstance(a, V1)
 
 
 @pytest.mark.parametrize('op', BINARY_OPS + BINARY_SCALAR_OPS + BOOL_OPS) # type: ignore

--- a/tests/test_vector2.py
+++ b/tests/test_vector2.py
@@ -18,28 +18,3 @@ negation_data = (
 @pytest.mark.parametrize('test_vector, expected_result', negation_data)
 def test_negation(test_vector, expected_result):
     assert -test_vector == expected_result
-
-
-@pytest.mark.parametrize('value', [
-    Vector2(1, 2),
-    [3, 4],
-    (5, 6),
-    {'x': 7, 'y': 8},
-])
-def test_convert(value):
-    v = Vector2.convert(value)
-    assert isinstance(v, Vector2)
-    assert v == value
-
-
-@pytest.mark.parametrize('value', [
-    Vector2(1, 2),
-    [3, 4],
-    (5, 6),
-    {'x': 7, 'y': 8},
-])
-def test_convert_subclass(value):
-    class V(Vector2): pass
-    v = V.convert(value)
-    assert isinstance(v, V)
-    assert v == value

--- a/tests/test_vector2.py
+++ b/tests/test_vector2.py
@@ -3,11 +3,6 @@ import pytest  # type: ignore
 from ppb_vector import Vector2
 
 
-def test_is_iterable():
-    test_vector = Vector2(3, 4)
-    test_tuple = tuple(test_vector)
-    assert test_tuple == (3, 4)
-
 negation_data = (
     (Vector2(1, 1), Vector2(-1, -1)),
     (Vector2(2, -3), Vector2(-2, 3)),

--- a/tests/test_vector2_ctor.py
+++ b/tests/test_vector2_ctor.py
@@ -1,0 +1,23 @@
+import pytest  # type: ignore
+from hypothesis import given
+from utils import floats, vectors, vector_likes
+
+from ppb_vector import Vector2
+
+
+class V(Vector2): pass
+
+
+@pytest.mark.parametrize('cls', [Vector2, V])
+@given(x=vectors())
+def test_ctor_vector_like(cls, x: Vector2):
+    for x_like in vector_likes(x):
+        vector = cls(x_like)
+        assert vector == x == x_like
+        assert isinstance(vector, cls)
+
+
+@pytest.mark.parametrize('cls', [Vector2, V])
+@given(x=floats(), y=floats())
+def test_ctor_coordinates(cls, x: float, y: float):
+    assert cls(x, y) == cls((x, y))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,7 +88,8 @@ UNARY_SCALAR_OPS = [
 ]
 
 
-# Sequence of vector-likes equivalent to the x unit vector
-UNIT_VECTOR_LIKES = (
-    (0, 1), [0, 1], {"x": 0, "y": 1}
-)
+# Sequence of vector-likes equivalent to the input vector (def. to the x vector)
+def vector_likes(v: Vector2=Vector2(1, 0)):
+    return (
+        (v.x, v.y), [v.x, v.y], {"x": v.x, "y": v.y}
+    )


### PR DESCRIPTION
Follow-up on #101; the commits from that feature branch are included, so please merge it first.

- [x] Add tests converting vectors to and from `dict`s.
- [x] Implement the `mapping` protocol, so `dict(some_vector)` works.

The PR seems to expose a bug in `mypy`, but this is snek sourcery beyond my ken, so I'd like one of you to have a look.