### PR TITLE
Travis: Run tests under PyPy

### DIFF
--- a/.ci/install-python.sh
+++ b/.ci/install-python.sh
@@ -9,13 +9,31 @@ if [[ "$TRAVIS_OS_NAME" != linux ]]; then
    exit 1
 fi
 
-MINICONDA_OS=Linux
-URL="https://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh"
-wget "${URL}" -O miniconda.sh
-bash miniconda.sh -b -p "$HOME/miniconda"
-export PATH="$HOME/miniconda/bin:$PATH"
-conda config --set always_yes yes --set changeps1 no
-conda update -q conda
-conda info -a
-conda create -q -n test-environment "python=$PYTHON"
-source activate test-environment
+if [[ "$PYTHON" =~ pypy-* ]]; then
+  # Download & install a prebuilt pypy snapshot
+  PYPY_BRANCH=${PYTHON#*-}
+  URL="http://buildbot.pypy.org/nightly/${PYPY_BRANCH}/pypy-c-jit-latest-linux64.tar.bz2"
+  wget "${URL}" -O pypy.tar.bz2
+  tar -xf pypy.tar.bz2
+  PYPY=( pypy-c-jit-* )
+
+  echo "Using ${PYPY}"
+  export PATH="${PWD}/${PYPY}/bin:${PATH}"
+  ln -s pypy3 "${PYPY}/bin/python"
+  python -m ensurepip
+  ln -s pip3 "${PYPY}/bin/pip"
+  pip install -U pip wheel
+
+else
+  # Install a Python version with miniconda
+  MINICONDA_OS=Linux
+  URL="https://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh"
+  wget "${URL}" -O miniconda.sh
+  bash miniconda.sh -b -p "$HOME/miniconda"
+  export PATH="$HOME/miniconda/bin:$PATH"
+  conda config --set always_yes yes --set changeps1 no
+  conda update -q conda
+  conda info -a
+  conda create -q -n test-environment "python=$PYTHON"
+  source activate test-environment
+fi

--- a/.ci/install-python.sh
+++ b/.ci/install-python.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Nothing to do if no specific Python version is requested
+[ -n "${PYTHON+x}" ] || return 0
+
+if [[ "$TRAVIS_OS_NAME" != linux ]]; then
+   echo "This script only supports linux, got \$TRAVIS_OS_NAME='${TRAVIS_OS_NAME}'" >&2
+   exit 1
+fi
+
+MINICONDA_OS=Linux
+URL="https://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh"
+wget "${URL}" -O miniconda.sh
+bash miniconda.sh -b -p "$HOME/miniconda"
+export PATH="$HOME/miniconda/bin:$PATH"
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+conda info -a
+conda create -q -n test-environment "python=$PYTHON"
+source activate test-environment

--- a/.ci/install-python.sh
+++ b/.ci/install-python.sh
@@ -17,25 +17,25 @@ if [[ "$PYTHON" =~ pypy-* ]]; then
   # Download & install a prebuilt pypy snapshot
   PYPY_BRANCH=${PYTHON#*-}
   URL="http://buildbot.pypy.org/nightly/${PYPY_BRANCH}/pypy-c-jit-latest-linux64.tar.bz2"
-  run wget "${URL}" -O pypy.tar.bz2
-  run tar -xf pypy.tar.bz2
-  PYPY=( pypy-c-jit-* )
+  run wget "${URL}" -O ../pypy.tar.bz2
+  run tar -C .. -xf ../pypy.tar.bz2
+  pushd ..; PYPY=( pypy-c-jit-* ); popd
 
   echo "Using ${PYPY}"
-  export PATH="${PWD}/${PYPY}/bin:${PATH}"
+  export PATH="$(realpath ../${PYPY}/bin):${PATH}"
   echo "PATH='${PATH}'"
 
-  run ln -s pypy3 "${PYPY}/bin/python"
+  run ln -s pypy3 "../${PYPY}/bin/python"
   run python -m ensurepip
-  run ln -s pip3 "${PYPY}/bin/pip"
+  run ln -s pip3 "../${PYPY}/bin/pip"
   run pip install -U pip wheel
 
 else
   # Install a Python version with miniconda
   MINICONDA_OS=Linux
   URL="https://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh"
-  run wget "${URL}" -O miniconda.sh
-  run bash miniconda.sh -b -p "$HOME/miniconda"
+  run wget "${URL}" -O ../miniconda.sh
+  run bash ../miniconda.sh -b -p "$HOME/miniconda"
   export PATH="$HOME/miniconda/bin:$PATH"
   echo "PATH='${PATH}'"
 

--- a/.ci/install-python.sh
+++ b/.ci/install-python.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-function run() {
-   echo '$' "$@"
-   "$@"
-}
 
 # Nothing to do if no specific Python version is requested
 [ -n "${PYTHON+x}" ] || return 0
+
+function run() {
+   echo '$' "$@"
+   "$@" || exit 1
+}
 
 if [[ "$TRAVIS_OS_NAME" != linux ]]; then
    echo "This script only supports linux, got \$TRAVIS_OS_NAME='${TRAVIS_OS_NAME}'" >&2

--- a/.ci/install-python.sh
+++ b/.ci/install-python.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
+
+function run() {
+   echo '$' "$@"
+   "$@"
+}
 
 # Nothing to do if no specific Python version is requested
 [ -n "${PYTHON+x}" ] || return 0
@@ -13,27 +18,27 @@ if [[ "$PYTHON" =~ pypy-* ]]; then
   # Download & install a prebuilt pypy snapshot
   PYPY_BRANCH=${PYTHON#*-}
   URL="http://buildbot.pypy.org/nightly/${PYPY_BRANCH}/pypy-c-jit-latest-linux64.tar.bz2"
-  wget "${URL}" -O pypy.tar.bz2
-  tar -xf pypy.tar.bz2
+  run wget "${URL}" -O pypy.tar.bz2
+  run tar -xf pypy.tar.bz2
   PYPY=( pypy-c-jit-* )
 
   echo "Using ${PYPY}"
   export PATH="${PWD}/${PYPY}/bin:${PATH}"
-  ln -s pypy3 "${PYPY}/bin/python"
-  python -m ensurepip
-  ln -s pip3 "${PYPY}/bin/pip"
-  pip install -U pip wheel
+  run ln -s pypy3 "${PYPY}/bin/python"
+  run python -m ensurepip
+  run ln -s pip3 "${PYPY}/bin/pip"
+  run pip install -U pip wheel
 
 else
   # Install a Python version with miniconda
   MINICONDA_OS=Linux
   URL="https://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh"
-  wget "${URL}" -O miniconda.sh
-  bash miniconda.sh -b -p "$HOME/miniconda"
+  run wget "${URL}" -O miniconda.sh
+  run bash miniconda.sh -b -p "$HOME/miniconda"
   export PATH="$HOME/miniconda/bin:$PATH"
-  conda config --set always_yes yes --set changeps1 no
-  conda update -q conda
-  conda info -a
-  conda create -q -n test-environment "python=$PYTHON"
-  source activate test-environment
+  run conda config --set always_yes yes --set changeps1 no
+  run conda update -q conda
+  run conda info -a
+  run conda create -q -n test-environment "python=$PYTHON"
+  run source activate test-environment
 fi

--- a/.ci/install-python.sh
+++ b/.ci/install-python.sh
@@ -24,6 +24,8 @@ if [[ "$PYTHON" =~ pypy-* ]]; then
 
   echo "Using ${PYPY}"
   export PATH="${PWD}/${PYPY}/bin:${PATH}"
+  echo "PATH='${PATH}'"
+
   run ln -s pypy3 "${PYPY}/bin/python"
   run python -m ensurepip
   run ln -s pip3 "${PYPY}/bin/pip"
@@ -36,6 +38,8 @@ else
   run wget "${URL}" -O miniconda.sh
   run bash miniconda.sh -b -p "$HOME/miniconda"
   export PATH="$HOME/miniconda/bin:$PATH"
+  echo "PATH='${PATH}'"
+
   run conda config --set always_yes yes --set changeps1 no
   run conda update -q conda
   run conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
           python: 3.6
         - os: linux
           language: generic
-          env: PYTHON="3.7" MINICONDA_OS="Linux"
+          env: PYTHON="3.7"
         - os: linux
           python: nightly
     allow_failures:
@@ -17,18 +17,7 @@ cache:
       - .hypothesis
 
 before_install:
-  - if [[ $MINICONDA_OS ]]; then
-      URL="https://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh";
-      wget "${URL}" -O miniconda.sh;
-      bash miniconda.sh -b -p $HOME/miniconda;
-      export PATH="$HOME/miniconda/bin:$PATH";
-      hash -r;
-      conda config --set always_yes yes --set changeps1 no;
-      conda update -q conda;
-      conda info -a;
-      conda create -q -n test-environment python=$PYTHON;
-      source activate test-environment;
-    fi;
+  - source ./.ci/install-python.sh
 
 install:
   - pip install -e .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+addons:
+  apt:
+    packages:
+      - realpath
+
 language: python
 matrix:
     fast_finish: yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 matrix:
+    fast_finish: yes
     include:
+        # CPython builds
         - os: linux
           python: 3.6
         - os: linux
@@ -8,8 +10,15 @@ matrix:
           env: PYTHON="3.7"
         - os: linux
           python: nightly
+
+        # PyPy builds
+        - os: linux
+          language: generic
+          env: PYTHON="pypy-py3.6"
+
     allow_failures:
         - python: "nightly"
+        - env: PYTHON="pypy-py3.6"
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ before_install:
 
 install:
   - pip install -e .;
+  - # Do not install mypy during pypy builds
+    '[[ ! "$PYTHON" =~ pypy-* ]] || sed -i "/^mypy/d" dev-requirements.txt'
   - pip install -r dev-requirements.txt;
-  
+
 script:
   - pytest --hypothesis-profile ci
-  - mypy ppb_vector tests
+  - '[[ "$PYTHON" =~ pypy-* ]] || mypy ppb_vector tests'
   - python -m doctest README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ addons:
     packages:
       - realpath
 
+sudo: no
 language: python
 matrix:
     fast_finish: yes


### PR DESCRIPTION
- [x] Extract the environment setup script to a separate file.
- [x] Improve the output from the setup script.
- [x] Support installing PyPy.
  Thanks to `matrix.fast_finish`, the Github check will go green without waiting on the PyPy builds.
- [x] Move downloads outside of the source directory.
   The pollution of the source dir caused pytest to scan the whole PyPy source tree.
- [x] Add the `sudo: no` setting to run on Travis' container infrastructure.
  We weren't doing anything as root, and container builds start much faster.