### PR TITLE
Travis: Update pip, wheel, and setuptools before installing anything

### DIFF
--- a/.ci/install-python.sh
+++ b/.ci/install-python.sh
@@ -28,7 +28,6 @@ if [[ "$PYTHON" =~ pypy-* ]]; then
   run ln -s pypy3 "../${PYPY}/bin/python"
   run python -m ensurepip
   run ln -s pip3 "../${PYPY}/bin/pip"
-  run pip install -U pip wheel
 
 else
   # Install a Python version with miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
   - source ./.ci/install-python.sh
 
 install:
+  - pip install -U pip wheel setuptools
   - pip install -e .;
   - # Do not install mypy during pypy builds
     '[[ ! "$PYTHON" =~ pypy-* ]] || sed -i "/^mypy/d" dev-requirements.txt'


### PR DESCRIPTION
This fixes the likely root cause of #112 (a pip bug).

Generally, it would be much better if we could build in a sensible environment with known & up-to-date versions of Python (and its basic tooling), but that's not an option with Travis.