### PR TITLE
Travis: Eagerly update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ before_install:
   - source ./.ci/install-python.sh
 
 install:
-  - pip install -U pip wheel setuptools
+  - pip install --upgrade-strategy eager -U pip wheel setuptools
   - pip install -e .;
   - # Do not install mypy during pypy builds
     '[[ ! "$PYTHON" =~ pypy-* ]] || sed -i "/^mypy/d" dev-requirements.txt'
-  - pip install -U -r dev-requirements.txt;
+  - pip install --upgrade-strategy eager -U -r dev-requirements.txt
   - pip list
 
 script:


### PR DESCRIPTION
This should mitigate `pip`'s inability to deal with [versionned dependencies], and will hopefully stop it from continuously breaking CI.

[versionned dependencies]: https://github.com/ppb/ppb-vector/pull/111#issuecomment-466770788