### PR TITLE
Optimize the memory behaviour of Vector2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 hypothesis
 mypy==0.641
 perf
+pympler
 pytest~=3.8

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -57,7 +57,7 @@ class Vector2:
     y: float
 
     # Tell CPython that this isn't an extendable dict
-    __slots__ = ('x', 'y')
+    __slots__ = ('x', 'y', '__weakref__')
 
     @typing.overload
     def __init__(self, x: typing.SupportsFloat, y: typing.SupportsFloat): pass

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -56,6 +56,9 @@ class Vector2:
     x: float
     y: float
 
+    # Tell CPython that this isn't an extendable dict
+    __slots__ = ('x', 'y')
+
     @typing.overload
     def __init__(self, x: typing.SupportsFloat, y: typing.SupportsFloat): pass
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -20,8 +20,8 @@ class DummyVector:
 
 @given(x=floats(), y=floats())
 def test_object_size(x, y):
-    """Check that Vector2 is 3 times smaller than a naïve version."""
-    assert sizeof(Vector2(x, y)) < sizeof(DummyVector(x, y)) / 3
+    """Check that Vector2 is 2 times smaller than a naïve version."""
+    assert sizeof(Vector2(x, y)) < sizeof(DummyVector(x, y)) / 2
 
 
 @given(v=vectors())

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,8 +1,10 @@
+import weakref
+
 from pympler.asizeof import asizeof as sizeof  # type: ignore
 from hypothesis import given
 
 from ppb_vector import Vector2
-from utils import floats
+from utils import floats, vectors
 
 
 class DummyVector:
@@ -20,3 +22,9 @@ class DummyVector:
 def test_object_size(x, y):
     """Check that Vector2 is 3 times smaller than a naïve version."""
     assert sizeof(Vector2(x, y)) < sizeof(DummyVector(x, y)) / 3
+
+
+@given(v=vectors())
+def test_weak_ref(v):
+    """Check that weak references can be made to Vector2s."""
+    assert weakref.ref(v) is not None

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,22 @@
+from pympler.asizeof import asizeof as sizeof  # type: ignore
+from hypothesis import given
+
+from ppb_vector import Vector2
+from utils import floats
+
+
+class DummyVector:
+    """A naïve representation of vectors."""
+
+    x: float
+    y: float
+
+    def __init__(self, x, y):
+        self.x = float(x)
+        self.y = float(y)
+
+
+@given(x=floats(), y=floats())
+def test_object_size(x, y):
+    """Check that Vector2 is 3 times smaller than a naïve version."""
+    assert sizeof(Vector2(x, y)) < sizeof(DummyVector(x, y)) / 3


### PR DESCRIPTION
- [x] Use pre-allocated [`__slots__`] rather than an implicit `__dict__`.
- [ ] ~Inform the GC that `Vector2` instances need not be tracked~

[`__slots__`]: https://docs.python.org/3/reference/datamodel.html#slots

## Rationale

We can expect users of `ppb-vector` to use very many instances, in part due to the immutable design (though Python's refcounting implementation should immediately collect unreachable vectors, this still creates memory churn), and in part because vectors are an essential datastructure in games development.

Moreover, memory churn and GC interactions can be the source of pauses and jitter, which are a problem for games.

As such, it makes sense to try and minimize the per-instance cost of using `Vector2`, especially if it comes with no cost in terms of ergonomics, and negligible maintenance burden.

## Expected effects

- The use of `__slots__` made each vector use over 3 times less memory.
  This was tested by hand (against the implementation in `master`) and there is also a test that compares `Vector2` against a naive representation of vectors (not based on `dataclasses`).

- Using `__slots__` should result in marginally-better performance.
  This can be tested with `tests/benchmark.py` but I cannot run it right now (my laptop is heavily loaded).

- ~Removing the need for GC tracking should result in shorter pauses.~
  ~I plan on testing that with the `hugs.py` example game.~