### PR TITLE
Tighten-up the default tolerances in Vector2.isclose

### DIFF
--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -241,7 +241,7 @@ class Vector2:
         return rv
 
     def isclose(self: VectorOrSub, other: VectorLike, *,
-                abs_tol: Realish = 1e-3, rel_tol: Realish = 1e-06,
+                abs_tol: Realish = 1e-09, rel_tol: Realish = 1e-09,
                 rel_to: typing.Sequence[VectorLike] = ()) -> bool:
         """
         Determine whether two vectors are close in value.

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -61,11 +61,11 @@ def test_remarkable_angles(angle, trig):
 
 
 data_close = [
-    (Vector2(3, -20), 53, Vector2(17.77816, -9.64039)),
-    (Vector2(math.pi, -1 * math.e), 30, Vector2(4.07984, -0.7833)),
-    (Vector2(math.pi, math.e), 67, Vector2(-1.27467, 3.95397)),
-    (Vector2(1, 0), 30, Vector2(math.sqrt(3) / 2, 0.5)),
-    (Vector2(1, 0), 60, Vector2(0.5, math.sqrt(3) / 2)),
+    (Vector2(1, 0), angle, Vector2(cos_t, sin_t))
+    for (angle, (sin_t, cos_t)) in remarkable_angles.items()
+] + [
+    (Vector2(1, 1), angle, Vector2(cos_t - sin_t, cos_t + sin_t))
+    for (angle, (sin_t, cos_t)) in remarkable_angles.items()
 ]
 
 

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -52,6 +52,13 @@ remarkable_angles.update({
     for angle, (sin_t, cos_t) in remarkable_angles.items()
 })
 
+## extend to negative angles
+remarkable_angles.update({
+    -angle: (-sin_t, cos_t)
+    for angle, (sin_t, cos_t) in remarkable_angles.items()
+})
+
+
 @pytest.mark.parametrize("angle, trig", remarkable_angles.items(),
                           ids=[str(x) for x in remarkable_angles]
 )

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -16,7 +16,9 @@ data_exact = [
     (Vector2(1, 1), 180, Vector2(-1, -1)),
 ]
 
-@pytest.mark.parametrize("input, angle, expected", data_exact)
+@pytest.mark.parametrize("input, angle, expected", data_exact,
+                         ids=[str(angle) for _, angle, _ in data_exact],
+)
 def test_exact_rotations(input, angle, expected):
     assert input.rotate(angle) == expected
     assert input.angle(expected) == angle

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -50,11 +50,13 @@ remarkable_angles.update({
     for angle, (sin_t, cos_t) in remarkable_angles.items()
 })
 
-@pytest.mark.parametrize("angle, trig", remarkable_angles.items())
+@pytest.mark.parametrize("angle, trig", remarkable_angles.items(),
+                          ids=[str(x) for x in remarkable_angles]
+)
 def test_remarkable_angles(angle, trig):
-    angle = math.radians(angle)
+    _angle = math.radians(angle)
     sin_t, cos_t = trig
-    sin_m, cos_m = math.sin(angle), math.cos(angle)
+    sin_m, cos_m = math.sin(_angle), math.cos(_angle)
 
     assert math.isclose(sin_t, sin_m)
     assert math.isclose(cos_t, cos_m)

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -1,4 +1,5 @@
 import math
+from math import sqrt
 
 import hypothesis.strategies as st
 import pytest  # type: ignore
@@ -7,12 +8,57 @@ from hypothesis import assume, example, given, note
 from ppb_vector import Vector2
 from utils import angle_isclose, angles, floats, vectors
 
+
 data_exact = [
     (Vector2(1, 1), -90, Vector2(1, -1)),
     (Vector2(1, 1), 0, Vector2(1, 1)),
     (Vector2(1, 1), 90, Vector2(-1, 1)),
     (Vector2(1, 1), 180, Vector2(-1, -1)),
 ]
+
+@pytest.mark.parametrize("input, angle, expected", data_exact)
+def test_exact_rotations(input, angle, expected):
+    assert input.rotate(angle) == expected
+    assert input.angle(expected) == angle
+
+
+# angle (in degrees) -> (sin, cos)
+## values from 0 to 45°
+## lifted from https://en.wikibooks.org/wiki/Trigonometry/Selected_Angles_Reference
+remarkable_angles = {
+    15: ((sqrt(6) - sqrt(2))/4, (sqrt(6) + sqrt(2))/4),
+    22.5: (sqrt(2 - sqrt(2))/2, sqrt(2 + sqrt(2))/2),
+    30: (0.5, sqrt(3)/2),
+    45: (sqrt(2)/2, sqrt(2)/2),
+}
+
+## extend up to 90°
+remarkable_angles.update({
+    90 - angle: (cos_t, sin_t)
+    for angle, (sin_t, cos_t) in remarkable_angles.items()
+})
+
+## extend up to 180°
+remarkable_angles.update({
+    angle + 90: (cos_t, -sin_t)
+    for angle, (sin_t, cos_t) in remarkable_angles.items()
+})
+
+## extend up to 360°
+remarkable_angles.update({
+    angle + 180: (-sin_t, -cos_t)
+    for angle, (sin_t, cos_t) in remarkable_angles.items()
+})
+
+@pytest.mark.parametrize("angle, trig", remarkable_angles.items())
+def test_remarkable_angles(angle, trig):
+    angle = math.radians(angle)
+    sin_t, cos_t = trig
+    sin_m, cos_m = math.sin(angle), math.cos(angle)
+
+    assert math.isclose(sin_t, sin_m)
+    assert math.isclose(cos_t, cos_m)
+
 
 data_close = [
     (Vector2(3, -20), 53, Vector2(17.77816, -9.64039)),
@@ -21,12 +67,6 @@ data_close = [
     (Vector2(1, 0), 30, Vector2(math.sqrt(3) / 2, 0.5)),
     (Vector2(1, 0), 60, Vector2(0.5, math.sqrt(3) / 2)),
 ]
-
-
-@pytest.mark.parametrize("input, angle, expected", data_exact)
-def test_exact_rotations(input, angle, expected):
-    assert input.rotate(angle) == expected
-    assert input.angle(expected) == angle
 
 
 @pytest.mark.parametrize("input, angle, expected", data_close)

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -142,7 +142,10 @@ def test_rotation_stability2(initial, angles):
         stepwise = stepwise.rotate(angle)
     note(f"Step-wise: {stepwise}")
 
-    assert fellswoop.isclose(stepwise)
+    # Increase the tolerance on this comparison,
+    # as stepwise rotations induce rounding errors
+    assert fellswoop.isclose(stepwise, rel_tol=1e-6)
+
     assert math.isclose(fellswoop.length, initial.length, rel_tol=1e-15)
 
 

--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -71,7 +71,10 @@ data_close = [
 ]
 
 
-@pytest.mark.parametrize("input, angle, expected", data_close)
+@pytest.mark.parametrize("input, angle, expected", data_close,
+                         ids=[f"(1,0).rotate({x})" for x in remarkable_angles] +
+                             [f"(1,1).rotate({x})" for x in remarkable_angles],
+)
 def test_close_rotations(input, angle, expected):
     assert input.rotate(angle).isclose(expected)
     assert angle_isclose(input.angle(expected), angle)


### PR DESCRIPTION
- [x] Set the default `abs_tol` and `rel_tol` on `Vector2.isclose` to 10⁻⁹, from resp. 10⁻³ and 10⁻⁶.
  This makes all tests using `Vector2.isclose` (with its defaults) require more precision.
  Aside from `isclose`'s own tests:
  - only `test_truncate_equivalent_to_scale` sets a non-default, absolute tolerance (0);
  - all tests that set a relative tolerance use a tighter one, with one documented exception.
- [x] Replace rotation testcases (`data_close`) with data generated from exact formulas.
  The previous test vectors (in particular involving (π, e)) were too rounded-up.
- [x] tests/rotate: Provide testcase ids for all parameterized tests.
  In the verbose `pytest` output, `test_close_rotations[(1,1).rotate(337.5)]` is much more human-friendly than `test_close_rotations[input54-337.5-expected54]`.