### PR TITLE
tests/rotate: Fix flakyness in test_rotation_stability

### DIFF
--- a/tests/test_vector2_rotate.py
+++ b/tests/test_vector2_rotate.py
@@ -154,7 +154,7 @@ def test_rotation_stability(angle, loops):
         stepwise = stepwise.rotate(angle)
     note(f"Step-wise: {stepwise}")
 
-    assert fellswoop.isclose(stepwise)
+    assert fellswoop.isclose(stepwise, rel_tol=1e-8)
     assert math.isclose(fellswoop.length, initial.length, rel_tol=1e-15)
 
 


### PR DESCRIPTION
Likely introduced in #119: Tighten-up the default tolerances in Vector2.isclose

This caused a [failure in CI](https://travis-ci.org/ppb/ppb-vector/jobs/509702544#L775) for #121.

Non-flakyness was ensured by running this Hypothesis test with `max_examples` set to half-a-million.