### PR TITLE
Remove the “copy constructor”

### DIFF
--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -57,30 +57,7 @@ class Vector2:
     # Tell CPython that this isn't an extendable dict
     __slots__ = ('x', 'y', '__weakref__')
 
-    @typing.overload
-    def __init__(self, x: typing.SupportsFloat, y: typing.SupportsFloat): pass
-
-    @typing.overload
-    def __init__(self, other: VectorLike): pass
-
-    def __init__(self, *args, **kwargs):
-        if args and kwargs:
-            raise TypeError("Got a mix of positional and keyword arguments")
-
-        if not args and not kwargs or len(args) > 2:
-            raise TypeError("Expected 1 vector-like or 2 float-like arguments, "
-                            f"got {len(args) + len(kwargs)}")
-
-        if kwargs and frozenset(kwargs) != {'x', 'y'}:
-            raise TypeError(f"Expected keyword arguments x and y, got: {kwargs.keys().join(', ')}")
-
-        if kwargs:
-            x, y = kwargs['x'], kwargs['y']
-        elif len(args) == 1:
-            x, y = Vector2.convert(args[0])
-        elif len(args) == 2:
-            x, y = args
-
+    def __init__(self, x: typing.SupportsFloat, y: typing.SupportsFloat):
         try:
             # The @dataclass decorator made the class frozen, so we need to
             #  bypass the class' default assignment function :

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -37,7 +37,7 @@ def test_convert_dict(vector: Vector2):
 @pytest.mark.parametrize("coerce", [tuple, list, Vector2.asdict])
 @given(x=vectors())
 def test_convert_roundtrip(coerce, x: Vector2):
-    assert x == Vector2(coerce(x))
+    assert x == Vector2.convert(coerce(x))
 
 
 @pytest.mark.parametrize("coerce", [tuple, list])

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -38,9 +38,3 @@ def test_convert_dict(vector: Vector2):
 @given(x=vectors())
 def test_convert_roundtrip(coerce, x: Vector2):
     assert x == Vector2.convert(coerce(x))
-
-
-@pytest.mark.parametrize("coerce", [tuple, list])
-@given(x=vectors())
-def test_convert_roundtrip_positional(coerce, x: Vector2):
-    assert x == Vector2(*coerce(x))

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -24,7 +24,7 @@ class V2(Vector2):
 
 
 @pytest.mark.parametrize("op", BINARY_OPS)
-@given(x=st.builds(V1, vectors()), y=st.builds(V1, units()))
+@given(x=st.builds(V1.convert, vectors()), y=st.builds(V1.convert, units()))
 def test_binop_same(op, x: V1, y: V2):
     assert isinstance(op(x, y), V1)
 
@@ -32,19 +32,19 @@ def test_binop_same(op, x: V1, y: V2):
 @pytest.mark.parametrize("op", BINARY_OPS)
 @given(x=vectors(), y=units())
 def test_binop_different(op, x: Vector2, y: Vector2):
-    assert isinstance(op(V1(x), V2(y)), (V1, V2))
-    assert isinstance(op(V2(x), V1(y)), (V1, V2))
+    assert isinstance(op(V1.convert(x), V2.convert(y)), (V1, V2))
+    assert isinstance(op(V2.convert(x), V1.convert(y)), (V1, V2))
 
 
 @pytest.mark.parametrize("op", BINARY_OPS)
-@given(x=st.builds(V1, vectors()), y=st.builds(V1, units()))
+@given(x=st.builds(V1.convert, vectors()), y=st.builds(V1.convert, units()))
 def test_binop_subclass(op, x: V1, y: V1):
-    assert isinstance(op(V11(x), y), V11)
-    assert isinstance(op(x, V11(y)), V11)
+    assert isinstance(op(V11.convert(x), y), V11)
+    assert isinstance(op(x, V11.convert(y)), V11)
 
 
 @pytest.mark.parametrize("op", SCALAR_OPS)
-@given(x=st.builds(V1, vectors()), scalar=floats())
+@given(x=st.builds(V1.convert, vectors()), scalar=floats())
 def test_vnumop(op, x: V1, scalar: float):
     try:
         assert isinstance(op(x, scalar), V1)
@@ -54,7 +54,7 @@ def test_vnumop(op, x: V1, scalar: float):
 
 
 @pytest.mark.parametrize("op", UNARY_OPS)
-@given(x=st.builds(V1, vectors()))
+@given(x=st.builds(V1.convert, vectors()))
 def test_monop(op, x):
     try:
         assert isinstance(op(x), V1)

--- a/tests/test_vector2_ctor.py
+++ b/tests/test_vector2_ctor.py
@@ -20,15 +20,6 @@ def test_ctor_roundtrip(cls, coerce, v: Vector2):
 
 
 @pytest.mark.parametrize("cls", [Vector2, V])
-@given(x=vectors())
-def test_ctor_vector_like(cls, x: Vector2):
-    for x_like in vector_likes(x):
-        vector = cls(x_like)
-        assert vector == x == x_like
-        assert isinstance(vector, cls)
-
-
-@pytest.mark.parametrize("cls", [Vector2, V])
 @given(x=floats(), y=floats())
 def test_ctor_coordinates(cls, x: float, y: float):
-    assert cls(x, y) == cls((x, y))
+    assert cls(x, y) == cls.convert((x, y))

--- a/tests/test_vector2_ctor.py
+++ b/tests/test_vector2_ctor.py
@@ -13,7 +13,10 @@ class V(Vector2):
 @pytest.mark.parametrize("coerce", [tuple, list])
 @given(v=vectors())
 def test_ctor_roundtrip(cls, coerce, v: Vector2):
-    assert v == cls(*coerce(v))
+    w = cls(*coerce(v))
+
+    assert v == w
+    assert isinstance(w, cls)
 
 
 @pytest.mark.parametrize("cls", [Vector2, V])

--- a/tests/test_vector2_ctor.py
+++ b/tests/test_vector2_ctor.py
@@ -9,10 +9,11 @@ class V(Vector2):
     pass
 
 
+@pytest.mark.parametrize("cls", [Vector2, V])
 @pytest.mark.parametrize("coerce", [tuple, list])
 @given(v=vectors())
-def test_ctor_roundtrip(coerce, v: Vector2):
-    assert v == Vector2(*coerce(v))
+def test_ctor_roundtrip(cls, coerce, v: Vector2):
+    assert v == cls(*coerce(v))
 
 
 @pytest.mark.parametrize("cls", [Vector2, V])

--- a/tests/test_vector2_ctor.py
+++ b/tests/test_vector2_ctor.py
@@ -10,9 +10,9 @@ class V(Vector2):
 
 
 @pytest.mark.parametrize("coerce", [tuple, list])
-@given(x=vectors())
-def test_ctor_roundtrip(coerce, x: Vector2):
-    assert x == Vector2(*coerce(x))
+@given(v=vectors())
+def test_ctor_roundtrip(coerce, v: Vector2):
+    assert v == Vector2(*coerce(v))
 
 
 @pytest.mark.parametrize("cls", [Vector2, V])

--- a/tests/test_vector2_ctor.py
+++ b/tests/test_vector2_ctor.py
@@ -9,6 +9,12 @@ class V(Vector2):
     pass
 
 
+@pytest.mark.parametrize("coerce", [tuple, list])
+@given(x=vectors())
+def test_ctor_roundtrip(coerce, x: Vector2):
+    assert x == Vector2(*coerce(x))
+
+
 @pytest.mark.parametrize("cls", [Vector2, V])
 @given(x=vectors())
 def test_ctor_vector_like(cls, x: Vector2):


### PR DESCRIPTION
Opened for discussion, folowing #23 

- [x] Switch tests to using `Vector2.convert` where necessary
- [x] Update/improve the constructor tests
- [x] Finally, remove the ability to construct with `Vector2(vector_like)`