### PR TITLE
tests/memory: re-enable test_object_size under CPython 3.8 & later

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
 hypothesis
 perf
-pympler; implementation_name == 'cpython'
+pympler>=0.7; implementation_name == 'cpython'
 pytest~=3.8

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -21,8 +21,6 @@ class DummyVector:
 
 @pytest.mark.skipif(sys.implementation.name != 'cpython',
                     reason="PyPy optimises __slots__ automatically.")
-@pytest.mark.skipif(sys.implementation.version.minor > 7,
-                    reason="Pympler 0.6 is broken under Python 3.8.  See pympler#74")
 @given(x=floats(), y=floats())
 def test_object_size(x, y):
     """Check that Vector2 is 2 times smaller than a naïve version."""


### PR DESCRIPTION
Requires pympler 0.7 or later, which fixes an incompatibility with CPython 3.8.

Closes #140