### PR TITLE
Update expectations of subclasses

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,12 +27,33 @@ PPB's 2D Vector class
         The Y coordinate of the vector
 
 
-Inheriting from :py:class:`Vector2`
------------------------------------
+Inheriting from :py:class:`ppb_vector.Vector2`
+----------------------------------------------
 
-Subclasses of :py:class:`Vector2` should provide a constructor that expects
-2 parameters (the cartesian coordinates :py:attribute:`Vector2.x` and ``y``).
+As :py:class:`ppb_vector.Vector2` implements :py:meth:`object.__new__`, subclasses that define
+additional attributes should redefine it. The simplest way to do so looks like
+so: ::
 
-As such, this precludes building subclasses where additional properties are
-preserved by vector operations, such as a ``ColoredVector``, without redefining
-all methods.
+  class LabeledVector(Vector2):
+      """Subclass of Vector2 that defines an additional attribute."""
+      label: str
+  
+      def __new__(cls, x, y, label):
+          self = super().__new__(cls, x, y)
+          object.__setattr__(self, 'label', label)
+          return self
+
+
+Using :py:meth:`object.__setattr__` is necessary because the class is frozen by
+the :py:func:`dataclasses.dataclass` decorator, and as such assigning attributes
+raises an exception.
+
+Some methods return another vector: binary operators (:py:meth:`+
+<ppb_vector.Vector2.__add__>`, :py:meth:`- <ppb_vector.Vector2.__sub__>`,
+:py:meth:`ppb_vector.Vector2.reflect`), scalar operators
+(:py:meth:`ppb_vector.Vector2.rotate`, :py:meth:`ppb_vector.Vector2.scale_by`,
+:py:meth:`ppb_vector.Vector2.scale_to`, :py:meth:`ppb_vector.Vector2.truncate`),
+and unary operators (:py:meth:`- <ppb_vector.Vector2.__neg__>`, :py:meth:`ppb_vector.Vector2.normalize`).
+Those methods return an instance of the subclass (see :py:data:`ppb_vector.vector2.Vector`), and
+preserve all attributes of ``self`` except the cartesian coordinates (``x`` and
+``y``).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,10 +30,12 @@ PPB's 2D Vector class
 Inheriting from :py:class:`ppb_vector.Vector2`
 ----------------------------------------------
 
-As :py:class:`ppb_vector.Vector2` implements :py:meth:`object.__new__`, subclasses that define
-additional attributes should redefine it. The simplest way to do so looks like
-so: ::
+As :py:class:`ppb_vector.Vector2` is a :py:func:`dataclasses.dataclass
+<dataclass>` that implements :py:meth:`object.__new__`, subclasses that define
+additional attributes should be frozen dataclasses, redefine ``__new__``, and not
+define ``__init__``. The simplest way to do so looks like so: ::
 
+  @dataclass(frozen=True, init=False)
   class LabeledVector(Vector2):
       """Subclass of Vector2 that defines an additional attribute."""
       label: str

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,13 +27,20 @@ PPB's 2D Vector class
         The Y coordinate of the vector
 
 
-Inheriting from :py:class:`ppb_vector.Vector2`
-----------------------------------------------
+Inheriting from :py:class:`Vector2<ppb_vector.Vector2>`
+-------------------------------------------------------
 
-As :py:class:`ppb_vector.Vector2` is a :py:func:`dataclasses.dataclass
-<dataclass>` that implements :py:meth:`object.__new__`, subclasses that define
-additional attributes should be frozen dataclasses, redefine ``__new__``, and not
-define ``__init__``. The simplest way to do so looks like so: ::
+.. py:currentmodule:: ppb_vector
+
+Subclasses that do not add attributes need not, and should not, define
+:py:meth:`__init__<object.__init__>` or :py:meth:`__new__<object.__new__>`.
+
+As :py:class:`Vector2` is a
+:py:func:`dataclass<dataclasses.dataclass>` that implements
+:py:meth:`__new__<object.__new__>`, subclasses that define additional attributes
+should be frozen dataclasses, redefine :py:meth:`__new__<object.__new__>`, and
+not define :py:meth:`__init__<object.__init__>`. The simplest way to do so looks
+like so: ::
 
   @dataclass(frozen=True, init=False)
   class LabeledVector(Vector2):
@@ -47,15 +54,16 @@ define ``__init__``. The simplest way to do so looks like so: ::
 
 
 Using :py:meth:`object.__setattr__` is necessary because the class is frozen by
-the :py:func:`dataclasses.dataclass` decorator, and as such assigning attributes
-raises an exception.
+the :py:func:`dataclass<dataclasses.dataclass>` decorator, and as such assigning
+attributes raises an exception.
 
-Some methods return another vector: binary operators (:py:meth:`+
-<ppb_vector.Vector2.__add__>`, :py:meth:`- <ppb_vector.Vector2.__sub__>`,
-:py:meth:`ppb_vector.Vector2.reflect`), scalar operators
-(:py:meth:`ppb_vector.Vector2.rotate`, :py:meth:`ppb_vector.Vector2.scale_by`,
-:py:meth:`ppb_vector.Vector2.scale_to`, :py:meth:`ppb_vector.Vector2.truncate`),
-and unary operators (:py:meth:`- <ppb_vector.Vector2.__neg__>`, :py:meth:`ppb_vector.Vector2.normalize`).
-Those methods return an instance of the subclass (see :py:data:`ppb_vector.vector2.Vector`), and
-preserve all attributes of ``self`` except the cartesian coordinates (``x`` and
-``y``).
+Some methods return another vector: binary operators
+(:py:meth:`+<Vector2.__add__>`, :py:meth:`- <Vector2.__sub__>`,
+:py:meth:`reflect<Vector2.reflect>`), scalar operators
+(:py:meth:`rotate<Vector2.rotate>`, :py:meth:`scale_by<Vector2.scale_by>`,
+:py:meth:`scale_to<Vector2.scale_to>`, :py:meth:`truncate<Vector2.truncate>`),
+and unary operators (:py:meth:`-<Vector2.__neg__>`,
+:py:meth:`normalize<Vector2.normalize>`). Those methods return an instance of
+the subclass (see :py:data:`Vector<vector2.Vector>`), and preserve all
+attributes of ``self`` except the cartesian coordinates (:py:attr:`x<Vector2.x>`
+and :py:attr:`y<Vector2.y>`).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,3 +25,14 @@ PPB's 2D Vector class
         :annotation: : float
        
         The Y coordinate of the vector
+
+
+Inheriting from :py:class:`Vector2`
+-----------------------------------
+
+Subclasses of :py:class:`Vector2` should provide a constructor that expects
+2 parameters (the cartesian coordinates :py:attribute:`Vector2.x` and ``y``).
+
+As such, this precludes building subclasses where additional properties are
+preserved by vector operations, such as a ``ColoredVector``, without redefining
+all methods.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,9 @@ Inheriting from :py:class:`Vector2<ppb_vector.Vector2>`
 
 .. py:currentmodule:: ppb_vector
 
+Subclasses interface contract
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Subclasses that do not add attributes need not, and should not, define
 :py:meth:`__init__<object.__init__>` or :py:meth:`__new__<object.__new__>`.
 
@@ -67,3 +70,17 @@ and unary operators (:py:meth:`-<Vector2.__neg__>`,
 the subclass (see :py:data:`Vector<vector2.Vector>`), and preserve all
 attributes of ``self`` except the cartesian coordinates (:py:attr:`x<Vector2.x>`
 and :py:attr:`y<Vector2.y>`).
+
+
+Performance considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:py:class:`Vector2` defines :py:data:`__slots__<object.__slots__>`,
+replacing the attributes dictionary with preallocated space.
+Subclasses aren't required to define :py:data:`__slots__<object.__slots__>`, in
+which case instances will use an attributes dictionary.
+
+It is however recommended to do so, for performance and memory-efficiency
+reasons (under CPython). In this case, :py:data:`__slots__<object.__slots__>`
+should be a class variable, whose value is an iterator listing the attributes
+added by the class; the iterator may be empty.

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -1,5 +1,4 @@
 import dataclasses
-import functools
 import typing
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -18,35 +17,6 @@ VectorLike = typing.Union[
     typing.Sequence[typing.SupportsFloat],  # TODO: Length 2
     typing.Mapping[str, typing.SupportsFloat],  # TODO: Length 2, keys 'x', 'y'
 ]
-
-
-@functools.lru_cache()
-def _find_lowest_type(left: typing.Type, right: typing.Type) -> typing.Type:
-    """
-    Guess which is the more specific type.
-    """
-    # Basically, see what classes are unique in each type's MRO and return who
-    # has the most.
-    lmro = set(left.__mro__)
-    rmro = set(right.__mro__)
-    if len(lmro) > len(rmro):
-        return left
-    elif len(rmro) > len(lmro):
-        return right
-    else:
-        # They're equal, just arbitrarily pick one
-        return left
-
-
-def _find_lowest_vector(left: typing.Type, right: typing.Type) -> typing.Type:
-    if left is right:
-        return left
-    elif not issubclass(left, Vector2):
-        return right
-    elif not issubclass(right, Vector2):
-        return left
-    else:
-        return _find_lowest_type(left, right)
 
 
 @dataclass(eq=False, frozen=True, init=False, repr=False)

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -209,12 +209,12 @@ class Vector2:
         >>> Vector2(1, 0) + (0, 1)
         Vector2(1.0, 1.0)
         """
-        rtype = _find_lowest_vector(type(other), type(self))
         try:
             other_x, other_y = Vector2._unpack(other)
         except ValueError:
             return NotImplemented
-        return rtype(self.x + other_x, self.y + other_y)
+
+        return self.update(x=self.x + other_x, y=self.y + other_y)
 
     def __sub__(self: Vector, other: VectorLike) -> Vector:
         """Subtract one vector from another.
@@ -225,12 +225,12 @@ class Vector2:
         >>> Vector2(3, 3) - (1, 1)
         Vector2(2.0, 2.0)
         """
-        rtype = _find_lowest_vector(type(other), type(self))
         try:
             other_x, other_y = Vector2._unpack(other)
         except ValueError:
             return NotImplemented
-        return rtype(self.x - other_x, self.y - other_y)
+
+        return self.update(x=self.x - other_x, y=self.y - other_y)
 
     def dot(self: Vector, other: VectorLike) -> float:
         """Dot product of two vectors.
@@ -253,7 +253,7 @@ class Vector2:
         Vector2(3.0, 6.0)
         """
         scalar = float(scalar)
-        return type(self)(scalar * self.x, scalar * self.y)
+        return self.update(x=scalar * self.x, y=scalar * self.y)
 
     @typing.overload
     def __mul__(self: Vector, other: VectorLike) -> float: pass
@@ -315,7 +315,7 @@ class Vector2:
         Vector2(1.0, 1.0)
         """
         other = float(other)
-        return type(self)(self.x / other, self.y / other)
+        return self.update(x=self.x / other, y=self.y / other)
 
     def __getitem__(self: Vector, item: typing.Union[str, int]) -> float:
         if hasattr(item, '__index__'):
@@ -468,7 +468,7 @@ class Vector2:
 
         x = self.x * r_cos - self.y * r_sin
         y = self.x * r_sin + self.y * r_cos
-        return type(self)(x, y)
+        return self.update(x=x, y=y)
 
     def normalize(self: Vector) -> Vector:
         """Return a vector with the same direction and unit length.

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -112,7 +112,7 @@ class Vector2:
             value = args[0]
             # Early return if the argument is a vector:
             #  __new__ returned the same vector, no need to (re)set x and y
-            if isinstance(args[0], type(self)):
+            if isinstance(value, type(self)):
                 return
 
             x, y = Vector2._unpack(value)

--- a/ppb_vector/vector2.py
+++ b/ppb_vector/vector2.py
@@ -86,6 +86,15 @@ class Vector2:
 
         - any instance of :py:class:`Vector2` or any subclass.
         """
+        if args and len(args) == 1:
+            value = args[0]
+            if isinstance(value, cls):
+                # Short circuit when a valid instance is provided
+                return value
+
+        return super().__new__(cls)
+
+    def __init__(self, *args, **kwargs):
         if args and kwargs:
             raise TypeError("Got a mix of positional and keyword arguments")
 
@@ -98,17 +107,18 @@ class Vector2:
 
         if kwargs:
             x, y = kwargs['x'], kwargs['y']
+
         elif len(args) == 1:
             value = args[0]
-            if isinstance(value, cls):
-                # Short circuit if already a valid instance
-                return value
+            # Early return if the argument is a vector:
+            #  __new__ returned the same vector, no need to (re)set x and y
+            if isinstance(args[0], type(self)):
+                return
 
             x, y = Vector2._unpack(value)
+
         elif len(args) == 2:
             x, y = args
-
-        self = super().__new__(cls)
 
         try:
             # The @dataclass decorator made the class frozen, so we need to
@@ -124,10 +134,8 @@ class Vector2:
         except ValueError:
             raise TypeError(f"{type(y).__name__} object not convertable to float")
 
-        return self
-
     def __reduce__(self):
-        return type(self).__new__, (type(self), self.x, self.y)
+        return type(self), (self.x, self.y)
 
     #: Return a new :py:class:`Vector2` replacing specified fields with new values.
     update = dataclasses.replace

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,5 +33,5 @@ select = C,E,F,I,W,B,B9
 ignore = E704
 max-line-length = 100
 
-application-import-names = ppb_vector,utils
+application-import-names = ppb_vector,test_subclass,utils
 import-order-style = smarkets

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,11 +1,19 @@
 import sys
 import weakref
+from dataclasses import dataclass
 
 import pytest  # type: ignore
 from hypothesis import given
 
 from ppb_vector import Vector2
+from test_subclass import LabeledVector
 from utils import floats, vectors
+
+
+@given(v=vectors())
+def test_weak_ref(v):
+    """Check that weak references can be made to Vector2s."""
+    assert weakref.ref(v) is not None
 
 
 class DummyVector:
@@ -29,7 +37,22 @@ def test_object_size(x, y):
     assert sizeof(Vector2(x, y)) < sizeof(DummyVector(x, y)) / 2
 
 
+@dataclass(frozen=True, init=False)
+class SlottedVector(Vector2):
+    """Subclass of Vector2 that defines an additional attribute & its slot."""
+    label: str
+    __slots__ = ('label',)
+
+    def __new__(cls, x, y, label):
+        self = super().__new__(cls, x, y)
+        object.__setattr__(self, 'label', label)
+        return self
+
+
+@pytest.mark.skipif(sys.implementation.name != 'cpython',
+                    reason="PyPy optimises __slots__ automatically.")
 @given(v=vectors())
-def test_weak_ref(v):
-    """Check that weak references can be made to Vector2s."""
-    assert weakref.ref(v) is not None
+def test_subclass_size(v):
+    """Check that the slots optimization works on subclasses."""
+    from pympler.asizeof import asizeof as sizeof  # type: ignore
+    assert sizeof(v) < sizeof(SlottedVector(*v, None)) < sizeof(LabeledVector(*v, None)) / 2

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -13,7 +13,7 @@ class LabeledVector(Vector2):
     label: str
 
     def __init__(self, x, y, label):
-        Vector2.__init__(self, x, y)
+        super().__init__(x, y)
         object.__setattr__(self, 'label', label)
 
 

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -18,6 +18,17 @@ class LabeledVector(Vector2):
         return self
 
 
+@given(v=vectors(), label_v=st.text())
+def test_subclass_copy(v: Vector2, label_v: str):
+    """Test that instances of the subclass can be copied."""
+    from copy import copy, deepcopy
+    v = LabeledVector(*v, label_v)  # type: ignore
+    w = copy(v)
+
+    assert v == w == deepcopy(v)
+    assert w.label == label_v
+
+
 @pytest.mark.parametrize("op", BINARY_OPS)
 @given(v=vectors(), label_v=st.text(), w=units(), label_w=st.text())
 def test_subclass_binops_both(op, v: Vector2, label_v: str, w: Vector2, label_w: str):

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -74,7 +74,7 @@ def test_subclass_scalar(op, v: Vector2, label: str, scalar: float):
     assert u.label == label
 
 
-@pytest.mark.parametrize("op", UNARY_OPS - set([Vector2]))
+@pytest.mark.parametrize("op", UNARY_OPS - {Vector2})
 @given(v=vectors(), label=st.text())
 def test_subclass_unary(op, v: Vector2, label: str):
     """Test that unary operators preserve extra attributes."""

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -29,6 +29,17 @@ def test_subclass_copy(v: Vector2, label_v: str):
     assert w.label == label_v
 
 
+@given(v=vectors(), label_v=st.text())
+def test_ctor_pickle(v: Vector2, label_v: str):
+    """Round-trip instances of the subclass through `pickle.{dumps,loads}`."""
+    import pickle
+    v = LabeledVector(*v, label_v)  # type: ignore
+    w = pickle.loads(pickle.dumps(v))
+
+    assert v == w
+    assert isinstance(w, LabeledVector)
+
+
 @pytest.mark.parametrize("op", BINARY_OPS)
 @given(v=vectors(), label_v=st.text(), w=units(), label_w=st.text())
 def test_subclass_binops_both(op, v: Vector2, label_v: str, w: Vector2, label_w: str):

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -12,10 +12,9 @@ class LabeledVector(Vector2):
     """Subclass of Vector2 that defines an additional attribute."""
     label: str
 
-    def __new__(cls, x, y, label):
-        self = super().__new__(cls, x, y)
+    def __init__(self, x, y, label):
+        Vector2.__init__(self, x, y)
         object.__setattr__(self, 'label', label)
-        return self
 
 
 @given(v=vectors(), label_v=st.text())

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+
+import pytest  # type: ignore
+from hypothesis import given, strategies as st
+
+from ppb_vector import Vector2
+from utils import *
+
+
+class LabeledVector(Vector2):
+    """Subclass of Vector2 that defines an additional attribute."""
+    label: str
+
+    def __new__(cls, x, y, label):
+        self = super().__new__(cls, x, y)
+        object.__setattr__(self, 'label', label)
+        return self
+
+
+@pytest.mark.parametrize("op", BINARY_OPS)
+@given(v=vectors(), label_v=st.text(), w=vectors(), label_w=st.text())
+def test_subclass_binops_both(op, v: Vector2, label_v: str, w: Vector2, label_w: str):
+    """Test that binary operators preserve attributes when applied to another LabelledVector."""
+    v = LabeledVector(*v, label_v)
+    w = LabeledVector(*w, label_w)
+    u = op(v, w)
+
+    assert isinstance(u, LabeledVector)
+    assert u.label == label_v
+
+
+@pytest.mark.parametrize("op", BINARY_OPS)
+@given(v=vectors(), label=st.text(), w=vectors())
+def test_subclass_binops_one(op, v: Vector2, label: str, w: Vector2):
+    """Test that binary operators preserve extra attributes when applied to a Vector2."""
+    v = LabeledVector(*v, label)
+    u = op(v, w)
+
+    assert isinstance(u, LabeledVector)
+    assert u.label == label
+
+
+@pytest.mark.parametrize("op", SCALAR_OPS)
+@given(v=vectors(), label=st.text(), scalar=floats())
+def test_subclass_scalar(op, v: Vector2, label: str, scalar: float):
+    """Test that scalar operators preserve extra attributes."""
+    v = LabeledVector(*v, label)
+    u = op(v, scalar)
+
+    assert isinstance(u, LabeledVector)
+    assert u.label == label
+
+
+@pytest.mark.parametrize("op", UNARY_OPS)
+@given(v=vectors(), label=st.text())
+def test_subclass_unary(op, v: Vector2, label: str):
+    """Test that unary operators preserve extra attributes."""
+    v = LabeledVector(*v, label)
+    u = op(v)
+
+    assert isinstance(u, LabeledVector)
+    assert u.label == label

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -22,8 +22,8 @@ class LabeledVector(Vector2):
 @given(v=vectors(), label_v=st.text(), w=units(), label_w=st.text())
 def test_subclass_binops_both(op, v: Vector2, label_v: str, w: Vector2, label_w: str):
     """Test that binary operators preserve attributes when applied to another LabelledVector."""
-    v = LabeledVector(*v, label_v)
-    w = LabeledVector(*w, label_w)
+    v = LabeledVector(*v, label_v)  # type: ignore
+    w = LabeledVector(*w, label_w)  # type: ignore
     u = op(v, w)
 
     assert isinstance(u, LabeledVector)
@@ -34,7 +34,7 @@ def test_subclass_binops_both(op, v: Vector2, label_v: str, w: Vector2, label_w:
 @given(v=vectors(), label=st.text(), w=units())
 def test_subclass_binops_one(op, v: Vector2, label: str, w: Vector2):
     """Test that binary operators preserve extra attributes when applied to a Vector2."""
-    v = LabeledVector(*v, label)
+    v = LabeledVector(*v, label)  # type: ignore
     u = op(v, w)
 
     assert isinstance(u, LabeledVector)
@@ -46,7 +46,7 @@ def test_subclass_binops_one(op, v: Vector2, label: str, w: Vector2):
 def test_subclass_scalar(op, v: Vector2, label: str, scalar: float):
     """Test that scalar operators preserve extra attributes."""
     assume(scalar != 0 and v.length != 0)
-    v = LabeledVector(*v, label)
+    v = LabeledVector(*v, label)  # type: ignore
     u = op(v, scalar)
 
     assert isinstance(u, LabeledVector)
@@ -58,7 +58,7 @@ def test_subclass_scalar(op, v: Vector2, label: str, scalar: float):
 def test_subclass_unary(op, v: Vector2, label: str):
     """Test that unary operators preserve extra attributes."""
     assume(v.length != 0)
-    v = LabeledVector(*v, label)
+    v = LabeledVector(*v, label)  # type: ignore
     u = op(v)
 
     assert isinstance(u, LabeledVector)

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -7,6 +7,7 @@ from ppb_vector import Vector2
 from utils import *
 
 
+@dataclass(frozen=True, init=False)
 class LabeledVector(Vector2):
     """Subclass of Vector2 that defines an additional attribute."""
     label: str

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -75,7 +75,7 @@ def test_subclass_scalar(op, v: Vector2, label: str, scalar: float):
     assert u.label == label
 
 
-@pytest.mark.parametrize("op", UNARY_OPS)
+@pytest.mark.parametrize("op", UNARY_OPS - set([Vector2]))
 @given(v=vectors(), label=st.text())
 def test_subclass_unary(op, v: Vector2, label: str):
     """Test that unary operators preserve extra attributes."""

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 import pytest  # type: ignore
-from hypothesis import given, strategies as st
+from hypothesis import assume, given, strategies as st
 
 from ppb_vector import Vector2
 from utils import *
@@ -19,7 +19,7 @@ class LabeledVector(Vector2):
 
 
 @pytest.mark.parametrize("op", BINARY_OPS)
-@given(v=vectors(), label_v=st.text(), w=vectors(), label_w=st.text())
+@given(v=vectors(), label_v=st.text(), w=units(), label_w=st.text())
 def test_subclass_binops_both(op, v: Vector2, label_v: str, w: Vector2, label_w: str):
     """Test that binary operators preserve attributes when applied to another LabelledVector."""
     v = LabeledVector(*v, label_v)
@@ -31,7 +31,7 @@ def test_subclass_binops_both(op, v: Vector2, label_v: str, w: Vector2, label_w:
 
 
 @pytest.mark.parametrize("op", BINARY_OPS)
-@given(v=vectors(), label=st.text(), w=vectors())
+@given(v=vectors(), label=st.text(), w=units())
 def test_subclass_binops_one(op, v: Vector2, label: str, w: Vector2):
     """Test that binary operators preserve extra attributes when applied to a Vector2."""
     v = LabeledVector(*v, label)
@@ -42,9 +42,10 @@ def test_subclass_binops_one(op, v: Vector2, label: str, w: Vector2):
 
 
 @pytest.mark.parametrize("op", SCALAR_OPS)
-@given(v=vectors(), label=st.text(), scalar=floats())
+@given(v=vectors(), label=st.text(), scalar=lengths())
 def test_subclass_scalar(op, v: Vector2, label: str, scalar: float):
     """Test that scalar operators preserve extra attributes."""
+    assume(scalar != 0 and v.length != 0)
     v = LabeledVector(*v, label)
     u = op(v, scalar)
 
@@ -56,6 +57,7 @@ def test_subclass_scalar(op, v: Vector2, label: str, scalar: float):
 @given(v=vectors(), label=st.text())
 def test_subclass_unary(op, v: Vector2, label: str):
     """Test that unary operators preserve extra attributes."""
+    assume(v.length != 0)
     v = LabeledVector(*v, label)
     u = op(v)
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -62,7 +62,7 @@ def test_monop(op, x):
         reject()
 
 
-@pytest.mark.parametrize("op", BINARY_OPS + BINARY_SCALAR_OPS + BOOL_OPS)  # type: ignore
+@pytest.mark.parametrize("op", BINARY_OPS | BINARY_SCALAR_OPS | BOOL_OPS)  # type: ignore
 @given(x=vectors(), y=units())
 def test_binop_vectorlike(op, x: Vector2, y: Vector2):
     """Test that `op` accepts a vector-like second parameter."""

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -40,7 +40,6 @@ def test_binop_different(op, x: Vector2, y: Vector2):
 @given(x=st.builds(V1, vectors()), y=st.builds(V1, units()))
 def test_binop_subclass(op, x: V1, y: V1):
     assert isinstance(op(V11(x), y), V11)
-    assert isinstance(op(x, V11(y)), V11)
 
 
 @pytest.mark.parametrize("op", SCALAR_OPS)

--- a/tests/test_vector2_ctor.py
+++ b/tests/test_vector2_ctor.py
@@ -50,3 +50,15 @@ def test_ctor_pickle(cls, v: Vector2):
 
     assert v == w
     assert isinstance(w, cls)
+
+
+@pytest.mark.parametrize("cls", [Vector2, V])
+@given(v=vectors())
+def test_ctor_copy(cls, v: Vector2):
+    """Test that Vector2 instances can be copied."""
+    from copy import copy, deepcopy
+    v = cls(v)
+
+    assert v == copy(v) == deepcopy(v)
+    assert isinstance(copy(v), cls)
+    assert isinstance(deepcopy(v), cls)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,28 +66,28 @@ def isclose(
 
 
 # List of operations that (Vector2, Vector2) -> Vector2
-BINARY_OPS = frozenset([Vector2.__add__, Vector2.__sub__, Vector2.reflect])
+BINARY_OPS = frozenset({Vector2.__add__, Vector2.__sub__, Vector2.reflect})
 
 # List of (Vector2, Vector2) -> scalar operations
-BINARY_SCALAR_OPS = frozenset([Vector2.angle, Vector2.dot])
+BINARY_SCALAR_OPS = frozenset({Vector2.angle, Vector2.dot})
 
 # List of (Vector2, Vector2) -> bool operations
-BOOL_OPS = frozenset([Vector2.__eq__, Vector2.isclose])
+BOOL_OPS = frozenset({Vector2.__eq__, Vector2.isclose})
 
 # List of operations that (Vector2, Real) -> Vector2
-SCALAR_OPS = frozenset([
+SCALAR_OPS = frozenset({
     Vector2.rotate, Vector2.scale_by, Vector2.scale_to, Vector2.truncate
-])
+})
 
 # List of operations that (Vector2) -> Vector2
-UNARY_OPS = frozenset([Vector2.__neg__, Vector2, Vector2.normalize])
+UNARY_OPS = frozenset({Vector2.__neg__, Vector2, Vector2.normalize})
 
 # List of (Vector2) -> scalar operations
-UNARY_SCALAR_OPS = frozenset([
+UNARY_SCALAR_OPS = frozenset({
     Vector2.length.fget,  # type: ignore
     # mypy fails to typecheck properties' attributes:
     #  https://github.com/python/mypy/issues/220
-])
+})
 
 
 # Sequence of vector-likes equivalent to the input vector (def. to the x vector)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,26 +66,28 @@ def isclose(
 
 
 # List of operations that (Vector2, Vector2) -> Vector2
-BINARY_OPS = [Vector2.__add__, Vector2.__sub__, Vector2.reflect]
+BINARY_OPS = frozenset([Vector2.__add__, Vector2.__sub__, Vector2.reflect])
 
 # List of (Vector2, Vector2) -> scalar operations
-BINARY_SCALAR_OPS = [Vector2.angle, Vector2.dot]
+BINARY_SCALAR_OPS = frozenset([Vector2.angle, Vector2.dot])
 
 # List of (Vector2, Vector2) -> bool operations
-BOOL_OPS = [Vector2.__eq__, Vector2.isclose]
+BOOL_OPS = frozenset([Vector2.__eq__, Vector2.isclose])
 
 # List of operations that (Vector2, Real) -> Vector2
-SCALAR_OPS = [Vector2.rotate, Vector2.scale_by, Vector2.scale_to, Vector2.truncate]
+SCALAR_OPS = frozenset([
+    Vector2.rotate, Vector2.scale_by, Vector2.scale_to, Vector2.truncate
+])
 
 # List of operations that (Vector2) -> Vector2
-UNARY_OPS = [Vector2.__neg__, Vector2, Vector2.normalize]
+UNARY_OPS = frozenset([Vector2.__neg__, Vector2, Vector2.normalize])
 
 # List of (Vector2) -> scalar operations
-UNARY_SCALAR_OPS = [
+UNARY_SCALAR_OPS = frozenset([
     Vector2.length.fget,  # type: ignore
     # mypy fails to typecheck properties' attributes:
     #  https://github.com/python/mypy/issues/220
-]
+])
 
 
 # Sequence of vector-likes equivalent to the input vector (def. to the x vector)


### PR DESCRIPTION
- [x] Document status quo.
- [x] Propose support of subclasses that define new attributes, described in documentation and tests.
  Those are required to be `dataclasses`, to implement `__new__`, and not to implement `__init__`.
- [x] Implement that support using `update()`
  Typing guarantees are weakened: returned vectors are now guaranteed to have the type of `self`.
- [x] Make the references friendlier, in the inheritance docs.
- [x] Measure whether there is a performance impact.
- [ ] Fix the performance regression.
- [ ] Fix the issue with `__new__` (see #146).