### PR TITLE
Cut a 1.0 Alpha 1 release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ppb-vector
-version = 0.4.0rc1
+version = 1.0a1
 author = Piper Thunstrom
 author_email = pathunstrom@gmail.com
 description = A basic game development Vector2 class.


### PR DESCRIPTION
Getting a pre-release onto PyPI allows us to unblock PPB and more easily get feedback from any testers.

Note that this is not expected to be final, and there are clearly issues we want to resolve before 1.0 final.

However, the basic API seems to have stabilized, so other projects (PPB) can move forward against this API.