### PR TITLE
Vector.__reduce__: Do not invoke __new__ directly

### DIFF
--- a/ppb_vector/__init__.py
+++ b/ppb_vector/__init__.py
@@ -124,7 +124,7 @@ class Vector:
         return self
 
     def __reduce__(self):
-        return Vector.__new__, (Vector, self.x, self.y)
+        return Vector, (self.x, self.y)
 
     #: Return a new :py:class:`Vector` replacing specified fields with new values.
     update = dataclasses.replace


### PR DESCRIPTION
This fixes a violation of the [protocol] for object construction:

> If `__new__` returns an instance of `cls`, then the new instance’s `__init__()` method will be invoked like `__init__(self[, ...])`, where `self` is the new instance and the remaining arguments are the same as were passed to `__new__`.

[protocol]: https://docs.python.org/3/reference/datamodel.html#object.__new__

@astronouth7303 seems [in agreement](https://github.com/ppb/ppb-vector/pull/146#discussion_r275949156)