### PR TITLE
Cirrus CI: upload build artifacts to Github and (test) PyPI

### DIFF
--- a/.ci/upload-build.sh
+++ b/.ci/upload-build.sh
@@ -7,7 +7,7 @@ if ! [[ -v CIRRUS_RELEASE ]]; then
 	exit 0
 fi
 
-REQUIRED_VARS=( GITHUB_TOKEN PYPI_{REPOSITORY,USER,PASSWORD} )
+REQUIRED_VARS=( GITHUB_TOKEN TWINE_{REPOSITORY_URL,USER,PASSWORD} )
 for var in "${REQUIRED_VARS[@]}"; do
 	if ! [[ -v "$var" ]]; then
 		echo "Please set environment variable '$var' !"
@@ -30,8 +30,4 @@ for fpath in "${files_to_upload[@]}"; do
 		$url_to_upload
 done
 
-twine upload \
-	--repository-url "$PYPI_REPOSITORY" \
-	--username "$PYPI_USERNAME" \
-	--password "$PYPI_PASSWORD" \
-	"${files_to_upload[@]}"
+twine upload "${files_to_upload[@]}"

--- a/.ci/upload-build.sh
+++ b/.ci/upload-build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Pilfered from https://cirrus-ci.org/examples/#release-assets
+set -euo pipefail
+
+if ! [[ -v CIRRUS_RELEASE ]]; then
+	echo "Not a release. No need to deploy!"
+	exit 0
+fi
+
+REQUIRED_VARS=( GITHUB_TOKEN PYPI_{REPOSITORY,USER,PASSWORD} )
+for var in "${REQUIRED_VARS[@]}"; do
+	if ! [[ -v "$var" ]]; then
+		echo "Please set environment variable '$var' !"
+		exit 1
+	fi
+done
+
+
+file_content_type="application/octet-stream"
+files_to_upload=( dist/* )
+
+for fpath in "${files_to_upload[@]}"; do
+	echo "Uploading '$fpath' to Github..."
+	name=$(basename "$fpath")
+	url_to_upload="https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=$name"
+	curl -X POST \
+		--data-binary @$fpath \
+		--header "Authorization: token $GITHUB_TOKEN" \
+		--header "Content-Type: $file_content_type" \
+		$url_to_upload
+done
+
+twine upload \
+	--repository-url "$PYPI_REPOSITORY" \
+	--username "$PYPI_USERNAME" \
+	--password "$PYPI_PASSWORD" \
+	"${files_to_upload[@]}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,6 +26,26 @@ lint_task:
     - pip list
     - ./lint.sh
 
+upload_task:
+  only_if: $CIRRUS_BRANCH == 'master' && $CIRRUS_RELEASE != ""
+  env:
+    PYPI_REPOSITORY: "https://test.pypi.org/legacy/"
+    PYPI_USER: pursuedpybot
+    PYPI_PASSWORD: "ENCRYPTED[31855ff9a080d4be75462409aa237fd116237b333f28cbfdadf0b3e3a15e2c9d542c4ab26d14323765b7e23072bcd126]"
+    GITHUB_TOKEN: "ENCRYPTED[6975bc1548d212e17af0529b0041745c188388461f0481c858db317ad2417c3a36014a019b3d6797e62f938098400d6c]"
+
+  container:
+    image: python:3.7-slim
+
+  install_script:
+    - pip install --upgrade-strategy eager -U -r requirements-upload.txt
+
+  script:
+    - ./setup.py sdist bdist_wheel
+    - ls -Al dist
+    - tar -tf dist/*.tar.*
+    - unzip -l dist/*.whl
+    - ./.ci/upload-build.sh
 
 
 FreeBSD_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,9 +29,9 @@ lint_task:
 upload_task:
   only_if: $CIRRUS_BRANCH == 'master' && $CIRRUS_RELEASE != ""
   env:
-    PYPI_REPOSITORY: "https://test.pypi.org/legacy/"
-    PYPI_USER: pursuedpybot
-    PYPI_PASSWORD: "ENCRYPTED[31855ff9a080d4be75462409aa237fd116237b333f28cbfdadf0b3e3a15e2c9d542c4ab26d14323765b7e23072bcd126]"
+    TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"
+    TWINE_USER: pursuedpybot
+    TWINE_PASSWORD: "ENCRYPTED[31855ff9a080d4be75462409aa237fd116237b333f28cbfdadf0b3e3a15e2c9d542c4ab26d14323765b7e23072bcd126]"
     GITHUB_TOKEN: "ENCRYPTED[6975bc1548d212e17af0529b0041745c188388461f0481c858db317ad2417c3a36014a019b3d6797e62f938098400d6c]"
 
   container:

--- a/requirements-upload.txt
+++ b/requirements-upload.txt
@@ -1,0 +1,4 @@
+setuptools >= 38.6.0
+wheel >= 0.31.0
+twine >= 1.11.0
+pip >= 19


### PR DESCRIPTION
- `requirements-upload.txt` taken from pursuedpybear;
- `.ci/upload-build.sh` inspired by Cirrus CI's [documentation];
- upload task uses account `pursuedpybear` on Github and `test.pypi.org`.

[documentation]: https://cirrus-ci.org/examples/#release-assets
