### PR TITLE
flake8: Enable warnings from the pep8-naming plugin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ test = pytest
 
 
 [flake8]
-select = C,E,F,I,W,B,B9
+select = C,E,F,I,N,W,B,B9
 ignore = E704
 max-line-length = 100
 


### PR DESCRIPTION
This was accidentally disabled in 1c54d9be5c120e3251877f387f07266b060c85a7