### PR TITLE
Test the trigonometry routine on remarkable angles

### DIFF
--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -28,34 +28,34 @@ def test_exact_rotations(input, angle, expected):
 #  values from 0 to 45°
 #  lifted from https://en.wikibooks.org/wiki/Trigonometry/Selected_Angles_Reference
 remarkable_angles = {
-    15: ((sqrt(6) - sqrt(2)) / 4, (sqrt(6) + sqrt(2)) / 4),
-    22.5: (sqrt(2 - sqrt(2)) / 2, sqrt(2 + sqrt(2)) / 2),
-    30: (0.5, sqrt(3) / 2),
+    15: ((sqrt(6) + sqrt(2)) / 4, (sqrt(6) - sqrt(2)) / 4),
+    22.5: (sqrt(2 + sqrt(2)) / 2, sqrt(2 - sqrt(2)) / 2),
+    30: (sqrt(3) / 2, 0.5),
     45: (sqrt(2) / 2, sqrt(2) / 2),
 }
 
 #  extend up to 90°
 remarkable_angles.update({
-    90 - angle: (cos_t, sin_t)
-    for angle, (sin_t, cos_t) in remarkable_angles.items()
+    90 - angle: (sin_t, cos_t)
+    for angle, (cos_t, sin_t) in remarkable_angles.items()
 })
 
 #  extend up to 180°
 remarkable_angles.update({
-    angle + 90: (cos_t, -sin_t)
-    for angle, (sin_t, cos_t) in remarkable_angles.items()
+    angle + 90: (-sin_t, cos_t)
+    for angle, (cos_t, sin_t) in remarkable_angles.items()
 })
 
 #  extend up to 360°
 remarkable_angles.update({
-    angle + 180: (-sin_t, -cos_t)
-    for angle, (sin_t, cos_t) in remarkable_angles.items()
+    angle + 180: (-cos_t, -sin_t)
+    for angle, (cos_t, sin_t) in remarkable_angles.items()
 })
 
 #  extend to negative angles
 remarkable_angles.update({
-    -angle: (-sin_t, cos_t)
-    for angle, (sin_t, cos_t) in remarkable_angles.items()
+    -angle: (cos_t, -sin_t)
+    for angle, (cos_t, sin_t) in remarkable_angles.items()
 })
 
 
@@ -67,7 +67,7 @@ def test_remarkable_angles(angle, trig):
     This is useful both as a consistency test of the table,
     and as a test of Vector._trig (which Vector.rotate uses).
     """
-    sin_t, cos_t = trig
+    cos_t, sin_t = trig
     cos_m, sin_m = Vector._trig(angle)
 
     assert isclose(sin_t, sin_m, abs_tol=0, rel_tol=1e-14)
@@ -76,10 +76,10 @@ def test_remarkable_angles(angle, trig):
 
 data_close = [
     (Vector(1, 0), angle, Vector(cos_t, sin_t))
-    for (angle, (sin_t, cos_t)) in remarkable_angles.items()
+    for (angle, (cos_t, sin_t)) in remarkable_angles.items()
 ] + [
     (Vector(1, 1), angle, Vector(cos_t - sin_t, cos_t + sin_t))
-    for (angle, (sin_t, cos_t)) in remarkable_angles.items()
+    for (angle, (cos_t, sin_t)) in remarkable_angles.items()
 ]
 
 

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -70,8 +70,8 @@ def test_remarkable_angles(angle, trig):
     sin_t, cos_t = trig
     cos_m, sin_m = Vector._trig(angle)
 
-    assert isclose(sin_t, sin_m)
-    assert isclose(cos_t, cos_m)
+    assert isclose(sin_t, sin_m, abs_tol=0, rel_tol=1e-14)
+    assert isclose(cos_t, cos_m, abs_tol=0, rel_tol=1e-14)
 
 
 data_close = [

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -62,12 +62,16 @@ remarkable_angles.update({
 @pytest.mark.parametrize("angle, trig", remarkable_angles.items(),
                          ids=[str(x) for x in remarkable_angles])
 def test_remarkable_angles(angle, trig):
-    _angle = math.radians(angle)
-    sin_t, cos_t = trig
-    sin_m, cos_m = math.sin(_angle), math.cos(_angle)
+    """Test that our table of remarkable angles agrees with Vector._trig.
 
-    assert math.isclose(sin_t, sin_m)
-    assert math.isclose(cos_t, cos_m)
+    This is useful both as a consistency test of the table,
+    and as a test of Vector._trig (which Vector.rotate uses).
+    """
+    sin_t, cos_t = trig
+    cos_m, sin_m = Vector._trig(angle)
+
+    assert isclose(sin_t, sin_m)
+    assert isclose(cos_t, cos_m)
 
 
 data_close = [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,6 @@
 from typing import Sequence, Union
 
 import hypothesis.strategies as st
-from hypothesis import note
 
 from ppb_vector import Vector
 
@@ -56,11 +55,6 @@ def isclose(
         *(abs(z) ** rel_exp for z in rel_to if isinstance(z, float)),
         *(z.length ** rel_exp for z in rel_to if isinstance(z, Vector)),
     )
-    note(f"rel_max = {rel_max}")
-    if rel_max > 0:
-        note(f"diff = {diff} = {diff/rel_max} * rel_max")
-    else:
-        note(f"diff = {diff}")
 
     return diff <= rel_max * rel_tol or diff <= abs_tol
 


### PR DESCRIPTION
- [x] Compare the remarkable angles to `Vector._trig`, and not `cos, sin`, in `test_remarkable_angles`.
- [x] Tighten-up the tolerances on that test.
- [x] Modify `utils.isclose` to be usable outside Hypothesis.
- [x] Modify `rotate/remarkable_angles` to use the same convention as `Vector._trig`.