### PR TITLE
Commit to semantic versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ pip install 'ppb-vector'
     Vector(3.0, 4.0)
 
 
-See the [online documentation] for an overview of the functionality.
+See the [API reference] for an overview of the functionality.
 
-[online documentation]: https://ppb-vector.readthedocs.io/en/latest/
+[API reference]: https://ppb-vector.readthedocs.io/en/latest/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install 'ppb-vector'
 
 ## Usage
 
-`Vector` is an immutable 2D Vector. Instantiated as expected: 
+`Vector` is an immutable 2D Vector, which is instantiated as expected: 
 
     >>> from ppb_vector import Vector
     >>> Vector(3, 4)

--- a/README.md
+++ b/README.md
@@ -23,4 +23,10 @@ pip install 'ppb-vector'
 
 See the [API reference] for an overview of the functionality.
 
+Version numbers follow the [semantic versioning] convention, so [requiring]
+`ppb-vector ~= 1.0` is appropriate for software developped against this release:
+the version specification will match any 1.x release, starting with 1.0.
+
 [API reference]: https://ppb-vector.readthedocs.io/en/latest/
+[semantic versioning]: https://semver.org
+[requiring]: https://www.python.org/dev/peps/pep-0508/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ PPB's 2D Vector class
 .. note::
    ``ppb-vector`` follows the semver_ (semantic versioning) convention.
    In a nutshell, we commit to forward compatibility within a major version:
-   code that works with v1.0 ought to work with any 1.x release.
+   code that works with version 1.0 ought to work with any 1.x release.
 
 .. _semver: https://semver.org
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,13 @@
 PPB's 2D Vector class
 =====================
 
+.. note::
+   ``ppb-vector`` follows the semver_ (semantic versioning) convention.
+   In a nutshell, we commit to forward compatibility within a major version:
+   code that works with v1.0 ought to work with any 1.x release.
+
+.. _semver: https://semver.org
+
 .. autoclass:: ppb_vector.Vector
    :members:
    :special-members:


### PR DESCRIPTION
Also snuck in 2 minor changes to `README.md`, as I didn't want to deal with conflicting PRs:
- call the RTD docs “API reference”;
- use complete sentences.