### PR TITLE
Expose the version number programatically.

### DIFF
--- a/ppb_vector/__init__.py
+++ b/ppb_vector/__init__.py
@@ -5,6 +5,9 @@ from math import atan2, copysign, cos, degrees, hypot, isclose, radians, sin, sq
 
 __all__ = ('Vector',)
 
+#: ppb_vector's current version.
+#: It follows the semantic versioning convention.
+__version__ = "1.0b1"
 
 # Anything convertable to a Vector, including lists, tuples, and dicts
 VectorLike = typing.Union[

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ppb-vector
-version = 1.0b1
+version = attr: ppb_vector.__version__
 author = Piper Thunstrom
 author_email = pathunstrom@gmail.com
 description = A basic game development Vector class.

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,6 @@ packages = ppb_vector
 python_requires = >= 3.6
 zip_safe = True
 
-setup_requires = pytest-runner
-
 [aliases]
 test = pytest
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ def requirements(section=None):
 
 # See setup.cfg for the actual configuration.
 setup(
+    # setup needs to be able to import the library, for attr: to work
+    setup_requires=requirements() + ['pytest-runner'],
     install_requires=requirements(),
     tests_require=requirements('tests'),
 )


### PR DESCRIPTION
This addresses the [feedback] I left Piper on the 1.0 release PR, _i.e._ the version info is now exposed programmatically without duplicating it across `setup.cfg` and `__init__.py`.

[feedback]: https://github.com/ppb/ppb-vector/pull/23#discussion_r289222439