### PR TITLE
tests/rotate: Pass integer parameters to hypothesis.st.integers

### DIFF
--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -111,7 +111,7 @@ def test_trig_stability(angle):
     assert fabs(1 - r_len) <= fabs(1 - t_len)
 
 
-@given(angle=angles(), n=st.integers(min_value=0, max_value=1e5))
+@given(angle=angles(), n=st.integers(min_value=0, max_value=100_000))
 def test_trig_invariance(angle: float, n: int):
     """Test that cos(θ), sin(θ) ≃ cos(θ + n*360°), sin(θ + n*360°)"""
     r_cos, r_sin = Vector._trig(angle)
@@ -123,7 +123,7 @@ def test_trig_invariance(angle: float, n: int):
     assert isclose(r_sin, n_sin, rel_to=[n / 1e9])
 
 
-@given(v=vectors(), angle=angles(), n=st.integers(min_value=0, max_value=1e5))
+@given(v=vectors(), angle=angles(), n=st.integers(min_value=0, max_value=10_000))
 def test_rotation_invariance(v: Vector, angle: float, n: int):
     """Check that rotating by angle and angle + n×360° have the same result."""
     rot_once = v.rotate(angle)


### PR DESCRIPTION
[Hypothesis #2117], released in v4.39.3, introduced tighter type annotations, causing `mypy` to reject int-representable floats as parameters to `st.integers`.

[Hypothesis #2117]: https://github.com/HypothesisWorks/hypothesis/pull/2117