### PR TITLE
Fix CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -110,7 +110,7 @@ task:
 macOS_task:
   skip: $CIRRUS_BRANCH =~ '.*\.tmp'
   osx_instance:
-    image: mojave-base
+    image: mojave-xcode-11
   env:
     PATH: ${HOME}/.pyenv/shims:${PATH}
     matrix:
@@ -119,7 +119,6 @@ macOS_task:
   install_script:
     # Per the pyenv homebrew recommendations.
     # https://github.com/pyenv/pyenv/wiki#suggested-build-environment
-    - sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
     - brew install openssl readline pyenv
     - pyenv install ${PYTHON}
     - pyenv global ${PYTHON}

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
 hypothesis
-perf
+pyperf
 pympler>=0.7; implementation_name == 'cpython'
 pytest~=3.8

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-import perf  # type: ignore
+import pyperf  # type: ignore
 
 from ppb_vector import Vector
 from utils import *
 
-r = perf.Runner()
+r = pyperf.Runner()
 x = Vector(1, 1)
 y = Vector(0, 1)
 scalar = 123

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -111,7 +111,7 @@ def test_trig_stability(angle):
     assert fabs(1 - r_len) <= fabs(1 - t_len)
 
 
-@given(angle=angles(), n=st.integers(min_value=0, max_value=1e5))
+@given(angle=angles(), n=st.integers(min_value=0, max_value=100_000))
 def test_trig_invariance(angle: float, n: int):
     """Test that cos(θ), sin(θ) ≃ cos(θ + n*360°), sin(θ + n*360°)"""
     r_cos, r_sin = Vector._trig(angle)
@@ -123,7 +123,7 @@ def test_trig_invariance(angle: float, n: int):
     assert isclose(r_sin, n_sin, rel_to=[n / 1e9])
 
 
-@given(v=vectors(), angle=angles(), n=st.integers(min_value=0, max_value=1e5))
+@given(v=vectors(), angle=angles(), n=st.integers(min_value=0, max_value=10_000))
 def test_rotation_invariance(v: Vector, angle: float, n: int):
     """Check that rotating by angle and angle + n×360° have the same result."""
     rot_once = v.rotate(angle)


### PR DESCRIPTION
This amalgamates the fixes from:
- #185 : Update after `perf` was renamed to `pyperf`.
- #186 : Update `tests/rotate` after Hypothesis published stricter type hints.

Moreover, this includes the following fix:
- Cirrus CI: Do not check certificate when installing the macOS SDK