### PR TITLE
CI: Add CPython 3.8 environment on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,6 +69,7 @@ FreeBSD_task:
     matrix:
       - PYTHON: 3.6
       - PYTHON: 3.7
+      - PYTHON: 3.8
   install_script:
     - PYVER=`echo $PYTHON | tr -d '.'`
     - PYPKG=py${PYVER}

--- a/bors.toml
+++ b/bors.toml
@@ -2,6 +2,7 @@ status = [
   "docs",
   "FreeBSD PYTHON:3.6",
   "FreeBSD PYTHON:3.7",
+  "FreeBSD PYTHON:3.8",
   "lint",
   "Linux python:3.6-slim",
   "Linux python:3.7-slim",


### PR DESCRIPTION
Split off from #182 as `python38` was failing to install/be found on the FreeBSD CI.