### PR TITLE
Vector: Add a decompose method for basis change

### DIFF
--- a/ppb_vector/__init__.py
+++ b/ppb_vector/__init__.py
@@ -3,6 +3,7 @@ import warnings
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from math import atan2, copysign, cos, degrees, hypot, isclose, radians, sin, sqrt
+from typing import Tuple
 
 __all__ = ('Vector',)
 
@@ -531,6 +532,22 @@ class Vector:
         warnings.warn("Vector.scale was renamed to `scale_to`",
                       DeprecationWarning)
         return self.scale_to(length)
+
+    def decompose(self, basis: VectorLike) -> 'Tuple[Vector, Vector]':
+        """Decomposes a vector as 2 components in a different basis.
+
+        :param basis: A :py:class:`Vector` or a vector-like, describing the first
+            component of the basis, which must be normalized.
+
+        >>> Vector(2, 3).decompose( (1, 0) )
+        (Vector(2.0, 0.0), Vector(0.0, 3.0))
+        """
+        basis = Vector(basis)
+        if not isclose(basis.length, 1):
+            raise ValueError("Decomposition requires a normalized vector.")
+
+        a = (self * basis) * basis
+        return a, self - a
 
     def reflect(self, surface_normal: VectorLike) -> 'Vector':
         """Reflect a vector against a surface.

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1,3 +1,6 @@
+import operator
+from functools import reduce
+
 from hypothesis import given, note
 
 from ppb_vector import Vector
@@ -20,7 +23,7 @@ def test_decompose_canonical(v: Vector):
 @given(v=vectors(), basis=units())
 def test_decompose_recombine(v: Vector, basis: Vector):
     """A vector is the sum of its decomposed components."""
-    assert sum(v.decompose(basis), start=ZERO).isclose(v)
+    assert reduce(operator.add, v.decompose(basis)).isclose(v)
 
 
 @given(v=vectors(), basis=units())

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1,0 +1,48 @@
+from hypothesis import given, note
+
+from ppb_vector import Vector
+from utils import angle_isclose, floats, units, vectors
+
+
+# TODO(nicoo): Replace with Vector.zero once #168 is merged.
+ZERO = Vector(0, 0)
+
+
+@given(v=vectors())
+def test_decompose_canonical(v: Vector):
+    """Decomposition against the canonical (x, y) basis is trivial."""
+    x, y = v.decompose((1, 0))
+
+    assert x == (v.x, 0)
+    assert y == (0, v.y)
+
+
+@given(v=vectors(), basis=units())
+def test_decompose_recombine(v: Vector, basis: Vector):
+    """A vector is the sum of its decomposed components."""
+    assert sum(v.decompose(basis), start=ZERO).isclose(v)
+
+
+@given(v=vectors(), basis=units())
+def test_decompose_angles(v: Vector, basis: Vector):
+    """Decomposition components are colinear and orthogonal to the basis."""
+    a, b = v.decompose(basis)
+
+    assert angle_isclose(basis.angle(a),  0, modulus=180) or a.isclose(ZERO)
+    assert angle_isclose(basis.angle(b), 90, modulus=180) or b.isclose(ZERO)
+
+
+@given(
+    v=vectors(), w=vectors(), λ=floats(),
+    basis=units(),
+)
+def test_dot_linear(v: Vector, w: Vector, λ: float, basis: Vector):
+    """Decomposition against a fixed basis is linear"""
+    inner = (v + λ * w).decompose(basis)
+    outer = tuple(map(lambda t: t[0] + λ * t[1],
+                      zip(v.decompose(basis), w.decompose(basis))))
+
+    note(f"inner: {inner}")
+    note(f"outer: {outer}")
+
+    assert all((x.isclose(y) for x, y in zip(inner, outer)))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,9 +32,9 @@ def units():
     return st.builds(UNIT_X.rotate, angles())
 
 
-def angle_isclose(x, y, epsilon=6.5e-5):
-    d = (x - y) % 360
-    return (d < epsilon) or (d > 360 - epsilon)
+def angle_isclose(x, y, epsilon=6.5e-5, modulus=360):
+    d = (x - y) % modulus
+    return (d < epsilon) or (d > modulus - epsilon)
 
 
 def isclose(


### PR DESCRIPTION
### Changes

- Extend `tests.utils.angle_isclose` to accept arbitrary moduli (like comparing angles up to 180°, if one doesn't care about sign)
- Add `Vector.decompose` and relevant tests


### Rationale

`Vector.decompose` lets one decompose any vector into 2 orthogonal components, the first of which is colinear to the provided `basis` vector.


### Extensions

We could accept non-normalized vectors, and/or non-orthogonal basis.
I felt this was out-of-scope for a first go at this.
