### PR TITLE
tests.utils: Require optional args be named where ambiguous

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,7 @@ def floats(max_magnitude=1e75):
     return st.floats(min_value=-max_magnitude, max_value=max_magnitude)
 
 
-def lengths(min_value=0, max_value=1e75):
+def lengths(*, min_value=0, max_value=1e75):
     return st.floats(min_value=min_value, max_value=max_value)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,9 +32,9 @@ def units():
     return st.builds(UNIT_X.rotate, angles())
 
 
-def angle_isclose(x, y, epsilon=6.5e-5):
-    d = (x - y) % 360
-    return (d < epsilon) or (d > 360 - epsilon)
+def angle_isclose(x, y, epsilon=6.5e-5, modulus=360):
+    d = (x - y) % modulus
+    return (d < epsilon) or (d > modulus - epsilon)
 
 
 def isclose(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,6 +40,7 @@ def angle_isclose(x, y, *, epsilon=6.5e-5, modulus=360):
 def isclose(
     x,
     y,
+    *,
     abs_tol: float = 1e-9,
     rel_tol: float = 1e-9,
     rel_exp: float = 1,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,7 +32,7 @@ def units():
     return st.builds(UNIT_X.rotate, angles())
 
 
-def angle_isclose(x, y, epsilon=6.5e-5, modulus=360):
+def angle_isclose(x, y, *, epsilon=6.5e-5, modulus=360):
     d = (x - y) % modulus
     return (d < epsilon) or (d > modulus - epsilon)
 


### PR DESCRIPTION
### Changes

- `tests.utils.angle_isclose`: Accept arbitrary moduli
  Same as from #206, avoids merge conflict.

- In `tests.utils` functions with multiple optional arguments, make those kw-only:
  `angle_isclose`, `isclose`, and `lengths` are affected, no changes needed at call-sites.
  

### Motivation

When there is more than one optional argument, using them positionally can cause
confusion and higher likelyhood of bugs.

Those aren't public interfaces, this change isn't breaking.
