### PR TITLE
Improve annotations and comments

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -10,7 +10,7 @@ run flake8 --version
 run flake8 --ignore E241,F403,F405,B011 \
     $([ $PY_MINOR -ge 10 ] || echo '--exclude tests/test_pattern_matching.py') \
     tests
-run flake8 --exclude tests/
+run flake8 *.py ppb_vector/
 
 # Exclusion due to https://github.com/python/mypy/pull/10191
 run ${PY} -m mypy ppb_vector tests --exclude test_pattern_matching.py

--- a/ppb_vector/__init__.py
+++ b/ppb_vector/__init__.py
@@ -1,3 +1,4 @@
+import sys
 import typing
 import warnings
 from collections.abc import Mapping, Sequence
@@ -12,12 +13,23 @@ __all__ = ('Vector',)
 __version__ = "1.0"
 
 
+# TODO: TypedDict is only available from the stdlib in Python 3.8 onwards
+if sys.version_info.minor >= 8:
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+
+# Mappings convertable to Vector
+VectorLikeDict = TypedDict('VectorLikeDict', {'x': SupportsFloat, 'y': SupportsFloat})
+
+
 # Anything convertable to a Vector, including lists, tuples, and dicts
 VectorLike = Union[
     'Vector',
     Tuple[SupportsFloat, SupportsFloat],
     typing.Sequence[SupportsFloat],  # TODO: Length 2
-    typing.Mapping[str, SupportsFloat],  # TODO: Length 2, keys 'x', 'y'
+    VectorLikeDict,
 ]
 
 

--- a/ppb_vector/__init__.py
+++ b/ppb_vector/__init__.py
@@ -1,5 +1,5 @@
 import sys
-import typing
+import typing  # TODO: In Py3.9 onwards, ABCs can be subscripted directly
 import warnings
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass

--- a/ppb_vector/__init__.py
+++ b/ppb_vector/__init__.py
@@ -3,7 +3,7 @@ import warnings
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from math import atan2, copysign, cos, degrees, hypot, isclose, radians, sin, sqrt
-from typing import Tuple
+from typing import Optional, SupportsFloat, Tuple, Union
 
 __all__ = ('Vector',)
 
@@ -13,11 +13,11 @@ __version__ = "1.0"
 
 
 # Anything convertable to a Vector, including lists, tuples, and dicts
-VectorLike = typing.Union[
+VectorLike = Union[
     'Vector',
-    typing.Tuple[typing.SupportsFloat, typing.SupportsFloat],
-    typing.Sequence[typing.SupportsFloat],  # TODO: Length 2
-    typing.Mapping[str, typing.SupportsFloat],  # TODO: Length 2, keys 'x', 'y'
+    Tuple[SupportsFloat, SupportsFloat],
+    typing.Sequence[SupportsFloat],  # TODO: Length 2
+    typing.Mapping[str, SupportsFloat],  # TODO: Length 2, keys 'x', 'y'
 ]
 
 
@@ -75,7 +75,7 @@ class Vector:
     __slots__ = ('x', 'y', '__weakref__')
 
     @typing.overload
-    def __new__(cls, x: typing.SupportsFloat, y: typing.SupportsFloat): pass
+    def __new__(cls, x: SupportsFloat, y: SupportsFloat): pass
 
     @typing.overload
     def __new__(cls, other: VectorLike): pass
@@ -138,8 +138,8 @@ class Vector:
         return Vector, (self.x, self.y)
 
     def update(self,
-               x: typing.Optional[typing.SupportsFloat] = None,
-               y: typing.Optional[typing.SupportsFloat] = None):
+               x: Optional[SupportsFloat] = None,
+               y: Optional[SupportsFloat] = None):
         """Return a new :py:class:`Vector` replacing specified fields with new values."""
         if x is None and y is None:
             return self
@@ -148,7 +148,7 @@ class Vector:
                       self.y if y is None else y)
 
     @staticmethod
-    def _unpack(value: VectorLike) -> typing.Tuple[float, float]:
+    def _unpack(value: VectorLike) -> Tuple[float, float]:
         if isinstance(value, Vector):
             return value.x, value.y
         elif isinstance(value, Sequence) and len(value) == 2:
@@ -246,7 +246,7 @@ class Vector:
         other_x, other_y = Vector._unpack(other)
         return self.x * other_x + self.y * other_y
 
-    def scale_by(self, scalar: typing.SupportsFloat) -> 'Vector':
+    def scale_by(self, scalar: SupportsFloat) -> 'Vector':
         """Compute a vector-scalar multiplication.
 
         >>> Vector(1, 2).scale_by(3)
@@ -263,7 +263,7 @@ class Vector:
     def __mul__(self, other: VectorLike) -> float: pass
 
     @typing.overload
-    def __mul__(self, other: typing.SupportsFloat) -> 'Vector': pass
+    def __mul__(self, other: SupportsFloat) -> 'Vector': pass
 
     def __mul__(self, other):
         """Perform a dot product or a scalar product, based on the parameter type.
@@ -305,12 +305,12 @@ class Vector:
     def __rmul__(self, other: VectorLike) -> float: pass
 
     @typing.overload
-    def __rmul__(self, other: typing.SupportsFloat) -> 'Vector': pass
+    def __rmul__(self, other: SupportsFloat) -> 'Vector': pass
 
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    def __truediv__(self, other: typing.SupportsFloat) -> 'Vector':
+    def __truediv__(self, other: SupportsFloat) -> 'Vector':
         """Perform a division between a vector and a scalar.
 
         >>> Vector(3, 3) / 3
@@ -319,7 +319,7 @@ class Vector:
         other = float(other)
         return Vector(self.x / other, self.y / other)
 
-    def __getitem__(self, item: typing.Union[str, int]) -> float:
+    def __getitem__(self, item: Union[str, int]) -> float:
         if hasattr(item, '__index__'):
             item = item.__index__()  # type: ignore
         if isinstance(item, str):
@@ -401,7 +401,7 @@ class Vector:
         return rv
 
     def isclose(self, other: VectorLike, *,
-                abs_tol: typing.SupportsFloat = 1e-09, rel_tol: typing.SupportsFloat = 1e-09,
+                abs_tol: SupportsFloat = 1e-09, rel_tol: SupportsFloat = 1e-09,
                 rel_to: typing.Sequence[VectorLike] = ()) -> bool:
         """Perform an approximate comparison of two vectors.
 
@@ -440,7 +440,7 @@ class Vector:
         return (diff <= rel_tol * rel_length or diff <= float(abs_tol))
 
     @staticmethod
-    def _trig(angle: typing.SupportsFloat) -> typing.Tuple[float, float]:
+    def _trig(angle: SupportsFloat) -> Tuple[float, float]:
         r = radians(angle)
         r_cos, r_sin = cos(r), sin(r)
 
@@ -457,7 +457,7 @@ class Vector:
 
         return r_cos, r_sin
 
-    def rotate(self, angle: typing.SupportsFloat) -> 'Vector':
+    def rotate(self, angle: SupportsFloat) -> 'Vector':
         """Rotate a vector.
 
         Rotate a vector in relation to the origin and return a new :py:class:`Vector`.
@@ -486,7 +486,7 @@ class Vector:
         """
         return self.scale_to(1)
 
-    def truncate(self, max_length: typing.SupportsFloat) -> 'Vector':
+    def truncate(self, max_length: SupportsFloat) -> 'Vector':
         """Scale a given :py:class:`Vector` down to a given length, if it is larger.
 
         >>> Vector(7, 24).truncate(3)
@@ -519,7 +519,7 @@ class Vector:
 
         return self.scale_to(max_length)
 
-    def scale_to(self, length: typing.SupportsFloat) -> 'Vector':
+    def scale_to(self, length: SupportsFloat) -> 'Vector':
         """Scale a given :py:class:`Vector` to a certain length.
 
         >>> Vector(7, 24).scale_to(2)
@@ -534,7 +534,7 @@ class Vector:
 
         return (length * self) / self.length
 
-    def scale(self, length: typing.SupportsFloat) -> 'Vector':
+    def scale(self, length: SupportsFloat) -> 'Vector':
         warnings.warn("Vector.scale was renamed to `scale_to`",
                       DeprecationWarning)
         return self.scale_to(length)

--- a/ppb_vector/__init__.py
+++ b/ppb_vector/__init__.py
@@ -68,6 +68,7 @@ class Vector:
     # Class-level attributes
     zero: typing.ClassVar['Vector']
 
+    # See https://www.python.org/dev/peps/pep-0622/#special-attribute-match-args
     __match_args__ = ('x', 'y')
 
     # Tell CPython that this isn't an extendable dict

--- a/ppb_vector/__init__.py
+++ b/ppb_vector/__init__.py
@@ -14,7 +14,7 @@ __version__ = "1.0"
 
 # Anything convertable to a Vector, including lists, tuples, and dicts
 VectorLike = typing.Union[
-    'Vector',  # Or subclasses, unconnected to the Vector typevar above
+    'Vector',
     typing.Tuple[typing.SupportsFloat, typing.SupportsFloat],
     typing.Sequence[typing.SupportsFloat],  # TODO: Length 2
     typing.Mapping[str, typing.SupportsFloat],  # TODO: Length 2, keys 'x', 'y'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+typing_extensions; python_version < '3.8'

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ def requirements(section=None):
 setup(
     # setup needs to be able to import the library, for attr: to work
     setup_requires=requirements() + ['pytest-runner'],
+    install_requires=requirements(),
     tests_require=requirements('tests'),
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ def requirements(section=None):
 
 # See setup.cfg for the actual configuration.
 setup(
-    # setup needs to be able to import the library, for attr: to work
     setup_requires=['pytest-runner'],
     tests_require=requirements('tests'),
 )

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ def requirements(section=None):
 
 # See setup.cfg for the actual configuration.
 setup(
-    setup_requires=['pytest-runner'],
+    # setup needs to be able to import the library, for attr: to work
+    setup_requires=requirements() + ['pytest-runner'],
     tests_require=requirements('tests'),
 )


### PR DESCRIPTION
- `VectorLike`
  * Nix obsoleted comment
  * Refine type definition for mappings
- Comment `Vector.__match_args__`
- Simplify references to the `typing` module
- Document deprecation of typing.{Sequence, Tuple, ...} from Python 3.9 onwards
- `lint.sh`: Avoid linting `.eggs/` and other directories
