### PR TITLE
Vector.decompose: Fix slightly-flaky test

### DIFF
--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -38,6 +38,8 @@ def test_decompose_angles(v: Vector, basis: Vector):
 
 @given(
     basis=units(), v=vectors(),
+    # We need |λw| ⩽ MAX_MAGNITUDE; picking |λ| and |w| below √MAX_MAGNITUDE
+    #  achieves that, though rejects some otherwise-valid combinations.
     λ=floats(max_magnitude=sqrt(MAX_MAGNITUDE)), w=vectors(sqrt(MAX_MAGNITUDE)),
 )
 def test_decompose_linear(v: Vector, w: Vector, λ: float, basis: Vector):

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -43,8 +43,7 @@ def test_decompose_angles(v: Vector, basis: Vector):
 def test_decompose_linear(v: Vector, w: Vector, λ: float, basis: Vector):
     """Decomposition against a fixed basis is linear"""
     inner = (v + λ * w).decompose(basis)
-    outer = tuple(map(lambda t: t[0] + λ * t[1],
-                      zip(v.decompose(basis), w.decompose(basis))))
+    outer = tuple((t + λ * u for t, u in zip(v.decompose(basis), w.decompose(basis))))
 
     note(f"inner: {inner}")
     note(f"outer: {outer}")

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -39,7 +39,7 @@ def test_decompose_angles(v: Vector, basis: Vector):
     v=vectors(), w=vectors(), λ=floats(),
     basis=units(),
 )
-def test_dot_linear(v: Vector, w: Vector, λ: float, basis: Vector):
+def test_decompose_linear(v: Vector, w: Vector, λ: float, basis: Vector):
     """Decomposition against a fixed basis is linear"""
     inner = (v + λ * w).decompose(basis)
     outer = tuple(map(lambda t: t[0] + λ * t[1],

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1,10 +1,11 @@
 import operator
 from functools import reduce
+from math import sqrt
 
 from hypothesis import given, note
 
 from ppb_vector import Vector
-from utils import angle_isclose, floats, units, vectors
+from utils import angle_isclose, floats, MAX_MAGNITUDE, units, vectors
 
 
 # TODO(nicoo): Replace with Vector.zero once #168 is merged.
@@ -36,8 +37,8 @@ def test_decompose_angles(v: Vector, basis: Vector):
 
 
 @given(
-    v=vectors(), w=vectors(), λ=floats(),
-    basis=units(),
+    basis=units(), v=vectors(),
+    λ=floats(max_magnitude=sqrt(MAX_MAGNITUDE)), w=vectors(sqrt(MAX_MAGNITUDE)),
 )
 def test_decompose_linear(v: Vector, w: Vector, λ: float, basis: Vector):
     """Decomposition against a fixed basis is linear"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,12 @@ def angles():
     return st.floats(min_value=-360, max_value=360)
 
 
+# The max magnitude of any “sensible” vector
+# 10⁷⁵ is a semi-arbitrary choice, but:
+# - It is sufficient to describe any game world; even using /picometers/ as the
+#   unit of length, the entire observable universe is “only” 9 × 10³⁸ pm across.
+# - It is slightly below 10⁷⁷≃2²⁵⁶, so squares are representable without issue
+#   in a `float` (or rather an IEEE754 binary64).
 MAX_MAGNITUDE = 1e75
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,15 +12,18 @@ def angles():
     return st.floats(min_value=-360, max_value=360)
 
 
-def floats(max_magnitude=1e75):
+MAX_MAGNITUDE = 1e75
+
+
+def floats(max_magnitude=MAX_MAGNITUDE):
     return st.floats(min_value=-max_magnitude, max_value=max_magnitude)
 
 
-def lengths(*, min_value=0, max_value=1e75):
+def lengths(*, min_value=0, max_value=MAX_MAGNITUDE):
     return st.floats(min_value=min_value, max_value=max_value)
 
 
-def vectors(max_magnitude=1e75):
+def vectors(max_magnitude=MAX_MAGNITUDE):
     return st.builds(
         Vector,
         st.floats(min_value=-max_magnitude, max_value=max_magnitude),


### PR DESCRIPTION
- utils: Make default MAX_MAGNITUDE into a constant
  This way, we can refer to the default vector magnitude rather than make up another threshold.

- tests/decompose: Fix name of linearity test
  While I was at it ;3

- tests/decompose/linear: Limit length of λv vector
  This is the actual fix
