### PR TITLE
Parallelise the testsuite in dev (as possible) and in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,7 +89,6 @@ FreeBSD_task:
 task:
   skip: $CIRRUS_BRANCH =~ '.*\.tmp'
   env:
-    PYTEST_CPUS: 8
     matrix:
       - IMAGE: python:3.7-slim
       - IMAGE: python:3.8-slim
@@ -103,8 +102,8 @@ task:
   name: "Linux $IMAGE"
   allow_failures: $IMAGE =~ '.*-rc-.*'
   container:
-    cpu: $PYTEST_CPUS
     image: $IMAGE
+    greedy: true
 
   install_script:
     - pip install --upgrade-strategy eager -U -r requirements-ci.txt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,6 +89,7 @@ FreeBSD_task:
 task:
   skip: $CIRRUS_BRANCH =~ '.*\.tmp'
   env:
+    PYTEST_CPUS: 8
     matrix:
       - IMAGE: python:3.7-slim
       - IMAGE: python:3.8-slim
@@ -102,6 +103,7 @@ task:
   name: "Linux $IMAGE"
   allow_failures: $IMAGE =~ '.*-rc-.*'
   container:
+    cpu: $PYTEST_CPUS
     image: $IMAGE
 
   install_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ FreeBSD_task:
     - PY=python${PYTHON}
     - pkg install -y bash python${PYVER} ${PYPKG}-setuptools
     - ${PY} -m ensurepip
-    - ${PY} -m pip install --upgrade-strategy eager -U -r requirements-tests.txt
+    - ${PY} -m pip install --upgrade-strategy eager -U -r requirements-ci.txt
     - ${PY} -m pip install -e .
 
   script:
@@ -105,7 +105,7 @@ task:
     image: $IMAGE
 
   install_script:
-    - pip install --upgrade-strategy eager -U -r requirements-tests.txt
+    - pip install --upgrade-strategy eager -U -r requirements-ci.txt
     - pip install -e .
 
   script:
@@ -134,7 +134,7 @@ macOS_task:
     - pyenv global ${PYTHON}
     - pyenv rehash
     - pip install --upgrade-strategy eager -U pip wheel setuptools
-    - pip install --upgrade-strategy eager -U -r requirements-tests.txt
+    - pip install --upgrade-strategy eager -U -r requirements-ci.txt
     - pip install .
 
   script:
@@ -173,7 +173,7 @@ task:
     image: $IMAGE
 
   install_script:
-    - C:\Python\python.exe -m pip install --upgrade-strategy eager -U -r requirements-tests.txt
+    - C:\Python\python.exe -m pip install --upgrade-strategy eager -U -r requirements-ci.txt
     - C:\Python\python.exe -m pip install -e .
 
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,8 +97,11 @@ task:
       - IMAGE: python:3-slim
       - IMAGE: python:rc-slim
       - IMAGE: pypy:3.7-slim
+        PYTEST_CPUS: 15
       - IMAGE: pypy:3-slim
+        PYTEST_CPUS: 15
       - IMAGE: pypy:3.8-slim
+        PYTEST_CPUS: 15
   name: "Linux $IMAGE"
   allow_failures: $IMAGE =~ '.*-rc-.*'
   container:

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,3 @@
+-r requirements-tests.txt
+
+pytest-xdist[psutils]

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,10 @@ else
     PYTEST_OPTIONS=( )
 fi
 
+# Autoparallelise the testsuite when pytest-xdist is available
+if ${PY} -m pip show -q pytest-xdist 2>/dev/null; then
+    PYTEST_OPTIONS+=( -n auto )
+fi
 
 run ${PY} -m doctest README.md ppb_vector/__init__.py
 run ${PY} -m pytest "${PYTEST_OPTIONS[@]}"

--- a/test.sh
+++ b/test.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 source .common.sh
 
+PYTEST_OPTIONS=()
+
 if [[ "${CI+x}" == x ]]; then
-    IN_CI=1
-    PYTEST_OPTIONS=( --hypothesis-profile ci )
-else
-    IN_CI=0
-    PYTEST_OPTIONS=( )
+		# Use a CI-specific profile for Hypothesis
+		PYTEST_OPTIONS+=( --hypothesis-profile ci )
+
+		# Autodetect the level of parallelism if unspecified
+		PYTEST_OPTIONS+=( -n "${PYTEST_CPUS-auto}" )
+
+elif ${PY} -m pip show -q pytest-xdist 2>/dev/null; then
+		# Autoparallelise the testsuite when pytest-xdist is available
+		PYTEST_OPTIONS=( -n auto )
 fi
 
-# Autoparallelise the testsuite when pytest-xdist is available
-if ${PY} -m pip show -q pytest-xdist 2>/dev/null; then
-    PYTEST_OPTIONS+=( -n auto )
-fi
 
 run ${PY} -m doctest README.md ppb_vector/__init__.py
 run ${PY} -m pytest "${PYTEST_OPTIONS[@]}"

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -9,10 +9,10 @@ x = Vector(1, 1)
 y = Vector(0, 1)
 scalar = 123
 
-for f in BINARY_OPS | BINARY_SCALAR_OPS | BOOL_OPS:  # type: ignore
+for f in BINARY_OPS + BINARY_SCALAR_OPS + BOOL_OPS:  # type: ignore
     r.bench_func(f.__name__, f, x, y)
 
-for f in UNARY_OPS | UNARY_SCALAR_OPS:  # type: ignore
+for f in UNARY_OPS + UNARY_SCALAR_OPS:  # type: ignore
     r.bench_func(f.__name__, f, x)
 
 for f in SCALAR_OPS:  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ def setup_hypothesis():
     from hypothesis import settings, Verbosity
 
     settings.register_profile("lots", max_examples=100_000)
-    settings.register_profile("ci", max_examples=1000)
+    settings.register_profile("ci", max_examples=1000, deadline=None)
     settings.register_profile("dev", max_examples=10)
     settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose)
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -5,7 +5,7 @@ from ppb_vector import Vector
 from utils import *
 
 
-@pytest.mark.parametrize("op", BINARY_OPS | BINARY_SCALAR_OPS | BOOL_OPS)  # type: ignore
+@pytest.mark.parametrize("op", BINARY_OPS + BINARY_SCALAR_OPS + BOOL_OPS)  # type: ignore
 @given(x=vectors(), y=units())
 def test_binop_vectorlike(op, x: Vector, y: Vector):
     """Test that `op` accepts a vector-like second parameter."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,28 +70,26 @@ def isclose(
 
 
 # List of operations that (Vector, Vector) -> Vector
-BINARY_OPS = frozenset({Vector.__add__, Vector.__sub__, Vector.reflect})
+BINARY_OPS = (Vector.__add__, Vector.__sub__, Vector.reflect)
 
 # List of (Vector, Vector) -> scalar operations
-BINARY_SCALAR_OPS = frozenset({Vector.angle, Vector.dot})
+BINARY_SCALAR_OPS = (Vector.angle, Vector.dot)
 
 # List of (Vector, Vector) -> bool operations
-BOOL_OPS = frozenset({Vector.__eq__, Vector.isclose})
+BOOL_OPS = (Vector.__eq__, Vector.isclose)
 
 # List of operations that (Vector, Real) -> Vector
-SCALAR_OPS = frozenset({
-    Vector.rotate, Vector.scale_by, Vector.scale_to, Vector.truncate,
-})
+SCALAR_OPS = (Vector.rotate, Vector.scale_by, Vector.scale_to, Vector.truncate)
 
 # List of operations that (Vector) -> Vector
-UNARY_OPS = frozenset({Vector.__neg__, Vector, Vector.normalize})
+UNARY_OPS = (Vector.__neg__, Vector, Vector.normalize)
 
 # List of (Vector) -> scalar operations
-UNARY_SCALAR_OPS = frozenset({
+UNARY_SCALAR_OPS = (
     Vector.length.fget,  # type: ignore
     # mypy fails to typecheck properties' attributes:
     #  https://github.com/python/mypy/issues/220
-})
+)
 
 
 # Sequence of vector-likes equivalent to the input vector (def. to the x vector)


### PR DESCRIPTION
### Changes

- [x] `test.sh` checks whether `pytest-xdist` is available, and if so runs the test suite in parallel
- [x] `pytest-xdist` is installed in CI's test environments
- [x] Introduce a new `requirements-ci.txt` for those environments, which cascades to `requirements-tests.txt`

### Motivation

Our test suite is getting slower, as it grows deeper and our API grows wider.  While unsurprising, this is an issue in 2 ways:

1. During (local) development, `test.sh` taking 8s is enough of a disruption that developers may subconsciously skip it, or specifically run a subset of the test suite, potentially missing issues which are only caught in CI once pushed, and getting much slower feedback.
2. In CI, `test.sh` takes about 1'30" (on Linux) which is long-enough one may skip to a different task etc., introducing further delays in the feedback loop, and more cognitive overhead from repeated context switching.  Ideally, I'd like our CI to complete within 10s of seconds (at least on PRs themselves, Bors may take longer as it's async)

Parallelising the test suite addresses both usecases:
1. `test.sh` got 4× faster in local development — 8s to 2s — fast-enough I could consider running it in a commit hook or such.
2. In the CI profile, the speedup was close to 8× — from 1'23" to 11" — which achieves my goal of getting feedback in tens of seconds.