### PR TITLE
CI/Lint: Simplify task requirements w/ cascading

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,6 @@ lint_task:
     image: python:3-slim
 
   install_script:
-    - pip install --upgrade-strategy eager -U -r requirements-tests.txt
     - pip install --upgrade-strategy eager -U -r requirements-lint.txt
     - pip install -e .
 

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,3 +1,6 @@
+# Necessary to be able to lint & typecheck the application and tests
+-r requirements-tests.txt
+
 flake8
 flake8-bugbear
 flake8-commas


### PR DESCRIPTION
I think it makes sense to have a single file specifying what we need for linting,
rather than what we need in addition of the test dependencies.

This uses the same feature of requirements files that #213 relies on, so nothing
new or more complex.
