### PR TITLE
test.sh: Run doctests through pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel"]  # PEP 508 specifications.
+requires = ["setuptools", "wheel"] # PEP 508 specifications.
 
 # Actually tell PEP517 tools to call setuptools
 build-backend = "setuptools.build_meta"
+
+# PyTest configuration
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--doctest-modules --doctest-glob=*.md"

--- a/test.sh
+++ b/test.sh
@@ -15,6 +15,4 @@ elif ${PY} -m pip show -q pytest-xdist 2>/dev/null; then
 		PYTEST_OPTIONS=( -n auto )
 fi
 
-
-run ${PY} -m doctest README.md ppb_vector/__init__.py
 run ${PY} -m pytest "${PYTEST_OPTIONS[@]}"

--- a/test.sh
+++ b/test.sh
@@ -15,4 +15,4 @@ elif ${PY} -m pip show -q pytest-xdist 2>/dev/null; then
 		PYTEST_OPTIONS=( -n auto )
 fi
 
-run ${PY} -m pytest "${PYTEST_OPTIONS[@]}"
+run ${PY} -m pytest "${PYTEST_OPTIONS[@]}" "$@"

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -4,16 +4,17 @@ import pyperf  # type: ignore
 from ppb_vector import Vector
 from utils import *
 
-r = pyperf.Runner()
-x = Vector(1, 1)
-y = Vector(0, 1)
-scalar = 123
+if __name__ == "__main__":
+    r = pyperf.Runner()
+    x = Vector(1, 1)
+    y = Vector(0, 1)
+    scalar = 123
 
-for f in BINARY_OPS + BINARY_SCALAR_OPS + BOOL_OPS:  # type: ignore
-    r.bench_func(f.__name__, f, x, y)
+    for f in BINARY_OPS + BINARY_SCALAR_OPS + BOOL_OPS:  # type: ignore
+        r.bench_func(f.__name__, f, x, y)
 
-for f in UNARY_OPS + UNARY_SCALAR_OPS:  # type: ignore
-    r.bench_func(f.__name__, f, x)
+    for f in UNARY_OPS + UNARY_SCALAR_OPS:  # type: ignore
+        r.bench_func(f.__name__, f, x)
 
-for f in SCALAR_OPS:  # type: ignore
-    r.bench_func(f.__name__, f, x, scalar)  # type: ignore
+    for f in SCALAR_OPS:  # type: ignore
+        r.bench_func(f.__name__, f, x, scalar)  # type: ignore


### PR DESCRIPTION
This way, we get much more cohesive output, and `test.sh` can (sensibly) pass through extra parameters to `pytest`, such as `--hypothesis-profile` or `--verbose`.
