### PR TITLE
Selectively run CI environments outside Bors

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,6 +37,7 @@ pep517_task:
     - python3 -m pep517.check .
 
 upload_task:
+  skip: $CIRRUS_BRANCH =~ '.*\.tmp'
   # only_if: $CIRRUS_RELEASE != ""
   env:
     TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,6 +63,7 @@ upload_task:
 
 FreeBSD_task:
   only_if: $BRANCH == 'staging' || $BRANCH == 'trying'
+  use_compute_credits: yes
   freebsd_instance:
     image_family: freebsd-13-0
   env:
@@ -120,6 +121,7 @@ task:
 
 macOS_task:
   only_if: $BRANCH == 'staging' || $BRANCH == 'trying'
+  use_compute_credits: yes
   osx_instance:
     image: catalina-xcode
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 docs_task:
-  skip: $CIRRUS_BRANCH =~ '.*\.tmp'
+  skip: $BRANCH =~ '.*\.tmp'
   container:
     image: python:3-slim
 
@@ -12,7 +12,7 @@ docs_task:
     - make -C docs/ html
 
 lint_task:
-  skip: $CIRRUS_BRANCH =~ '.*\.tmp'
+  skip: $BRANCH =~ '.*\.tmp'
   container:
     image: python:3-slim
 
@@ -26,7 +26,7 @@ lint_task:
     - ./lint.sh
 
 pep517_task:
-  skip: $CIRRUS_BRANCH =~ '.*\.tmp'
+  skip: $BRANCH =~ '.*\.tmp'
   container:
     image: python:3-slim
 
@@ -37,7 +37,7 @@ pep517_task:
     - python3 -m pep517.check .
 
 upload_task:
-  skip: $CIRRUS_BRANCH =~ '.*\.tmp'
+  skip: $BRANCH =~ '.*\.tmp'
   # only_if: $CIRRUS_RELEASE != ""
   env:
     TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"
@@ -88,7 +88,7 @@ FreeBSD_task:
     - ./test.sh
 
 task:
-  skip: $CIRRUS_BRANCH =~ '.*\.tmp'
+  skip: $BRANCH =~ '.*\.tmp'
   env:
     matrix:
       - IMAGE: python:3.7-slim
@@ -146,7 +146,7 @@ macOS_task:
     - ./test.sh
 
 task:
-  skip: $CIRRUS_BRANCH =~ '.*\.tmp'
+  skip: $BRANCH =~ '.*\.tmp'
   env:
     matrix:
       - IMAGE: python:3.7-windowsservercore

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,6 +89,7 @@ FreeBSD_task:
 
 task:
   skip: $BRANCH =~ '.*\.tmp'
+  use_compute_credits: $BRANCH == 'staging' || $BRANCH == 'trying'
   env:
     matrix:
       - IMAGE: python:3.7-slim
@@ -147,6 +148,7 @@ macOS_task:
 
 task:
   skip: $BRANCH =~ '.*\.tmp'
+  use_compute_credits: $BRANCH == 'staging' || $BRANCH == 'trying'
   env:
     matrix:
       - IMAGE: python:3.7-windowsservercore

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,7 +62,7 @@ upload_task:
 
 
 FreeBSD_task:
-  skip: $CIRRUS_BRANCH =~ '.*\.tmp'
+  only_if: $BRANCH == 'staging' || $BRANCH == 'trying'
   freebsd_instance:
     image_family: freebsd-13-0
   env:
@@ -119,7 +119,7 @@ task:
     - ./test.sh
 
 macOS_task:
-  skip: $CIRRUS_BRANCH =~ '.*\.tmp'
+  only_if: $BRANCH == 'staging' || $BRANCH == 'trying'
   osx_instance:
     image: catalina-xcode
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,7 +63,7 @@ upload_task:
 
 FreeBSD_task:
   only_if: $BRANCH == 'staging' || $BRANCH == 'trying'
-  use_compute_credits: yes
+  use_compute_credits: true
   freebsd_instance:
     image_family: freebsd-13-0
   env:
@@ -122,7 +122,7 @@ task:
 
 macOS_task:
   only_if: $BRANCH == 'staging' || $BRANCH == 'trying'
-  use_compute_credits: yes
+  use_compute_credits: true
   osx_instance:
     image: catalina-xcode
   env:


### PR DESCRIPTION
### Motivation

CI is currently slow, both in providing feedback on PRs, and in clearing through
Bors requests.

The issues compound when a PR branch is updated, causing a flurry of jobs to be
executed, right before Bors is instructed to merge, as both are competing for
jobs to be scheduled, under a shared concurrency limit.

### Main changes

- Skip “expensive” environments (FreeBSD, macOS) on immediate PR feedback.  
  They still run under Bors, enforving tests pass there, but we avoid consuming
  scarce, free CI time.
  
- Use PPB's compute credits for test tasks Bors is waiting on.
